### PR TITLE
fix(shim): evict empty/unparseable pending-update artifacts (JUNIE-2957)

### DIFF
--- a/install-experimental.ps1
+++ b/install-experimental.ps1
@@ -154,6 +154,33 @@ set "VERSIONS_DIR=%JUNIE_DATA%\versions"
 set "UPDATES_DIR=%JUNIE_DATA%\updates"
 set "CURRENT_FILE=%JUNIE_DATA%\current"
 set "PENDING_UPDATE=%UPDATES_DIR%\pending-update.json"
+set "PROCESSING=%UPDATES_DIR%\pending-update.json.processing"
+
+::: === Defensive Sanitization ===
+:::
+::: JUNIE-2957 defense: drop pending-update.json / pending-update.json.processing
+::: if they are empty or unparseable BEFORE the atomic-claim rename below. A
+::: legitimate in-flight update writes the manifest fully and then renames it,
+::: so a zero-byte file or one missing `version`/`zipPath` can only be junk --
+::: a leftover from a prior crash or content planted by mistake. Without this,
+::: a stale .processing blocks all future updates AND can be inherited by the
+::: binary's own update path with CWD as a working-dir hint.
+if exist "%PENDING_UPDATE%" (
+  set "PEND_OK="
+  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '%PENDING_UPDATE%' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c ^| ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PEND_OK=%%V"
+  if /i not "!PEND_OK!"=="ok" (
+    echo [Junie] Removing invalid update artifact: %PENDING_UPDATE% 1>&2
+    del /f /q "%PENDING_UPDATE%" 2>nul
+  )
+)
+if exist "!PROCESSING!" (
+  set "PROC_OK="
+  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '!PROCESSING!' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c ^| ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PROC_OK=%%V"
+  if /i not "!PROC_OK!"=="ok" (
+    echo [Junie] Removing invalid update artifact: !PROCESSING! 1>&2
+    del /f /q "!PROCESSING!" 2>nul
+  )
+)
 
 :: === Apply Pending Update ===
 if not exist "%PENDING_UPDATE%" goto :resolve_version

--- a/install-experimental.sh
+++ b/install-experimental.sh
@@ -257,6 +257,40 @@ detect_archive_type() {
   esac
 }
 
+# === Defensive Sanitization ===
+#
+# JUNIE-2957 defense: drop update artifacts that are empty or unparseable
+# BEFORE we (or the binary's own update path) act on them.
+#
+# A legitimate in-flight update writes the manifest fully and only then renames
+# it into place, so an existing `pending-update.json` or
+# `pending-update.json.processing` that is zero bytes, or that lacks the
+# required `version` / `zipPath` fields, can only be junk -- a leftover from a
+# prior crash, a partial write, or content planted by mistake. We must not feed
+# that to either `apply_pending_update` below or to the launched binary, which
+# may otherwise try to "resolve" paths derived from CWD/EJ_RUNNER_PWD.
+#
+# Best-effort: any rm failure is swallowed; the regular `apply_pending_update`
+# path will then handle the file conservatively or skip it.
+sanitize_pending_updates() {
+  [[ -d "$UPDATES_DIR" ]] || return 0
+  local f v z
+  for f in "$PENDING_UPDATE" "$UPDATES_DIR/pending-update.json.processing"; do
+    [[ -f "$f" ]] || continue
+    if [[ ! -s "$f" ]]; then
+      log_both "Removing zero-byte update artifact: $f"
+      rm -f "$f" 2>/dev/null || true
+      continue
+    fi
+    v=$(get_json_field "$f" "version")
+    z=$(get_json_field "$f" "zipPath")
+    if [[ -z "$v" || -z "$z" ]]; then
+      log_both "Removing unparseable update artifact (missing version/zipPath): $f"
+      rm -f "$f" 2>/dev/null || true
+    fi
+  done
+}
+
 # === Apply Pending Update ===
 #
 # Atomic extraction strategy:
@@ -557,6 +591,10 @@ handle_shim_commands() {
 main() {
   # Handle shim-specific commands
   handle_shim_commands "$@"
+
+  # Defense-in-depth (JUNIE-2957): drop empty / unparseable update artifacts
+  # before either we or the launched binary react to them.
+  sanitize_pending_updates
 
   # Apply pending update if present. On failure we deliberately do NOT abort:
   # the previous version is still on disk (via the `current` symlink) and should run.

--- a/install-nightly.ps1
+++ b/install-nightly.ps1
@@ -154,6 +154,33 @@ set "VERSIONS_DIR=%JUNIE_DATA%\versions"
 set "UPDATES_DIR=%JUNIE_DATA%\updates"
 set "CURRENT_FILE=%JUNIE_DATA%\current"
 set "PENDING_UPDATE=%UPDATES_DIR%\pending-update.json"
+set "PROCESSING=%UPDATES_DIR%\pending-update.json.processing"
+
+::: === Defensive Sanitization ===
+:::
+::: JUNIE-2957 defense: drop pending-update.json / pending-update.json.processing
+::: if they are empty or unparseable BEFORE the atomic-claim rename below. A
+::: legitimate in-flight update writes the manifest fully and then renames it,
+::: so a zero-byte file or one missing `version`/`zipPath` can only be junk --
+::: a leftover from a prior crash or content planted by mistake. Without this,
+::: a stale .processing blocks all future updates AND can be inherited by the
+::: binary's own update path with CWD as a working-dir hint.
+if exist "%PENDING_UPDATE%" (
+  set "PEND_OK="
+  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '%PENDING_UPDATE%' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c ^| ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PEND_OK=%%V"
+  if /i not "!PEND_OK!"=="ok" (
+    echo [Junie] Removing invalid update artifact: %PENDING_UPDATE% 1>&2
+    del /f /q "%PENDING_UPDATE%" 2>nul
+  )
+)
+if exist "!PROCESSING!" (
+  set "PROC_OK="
+  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '!PROCESSING!' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c ^| ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PROC_OK=%%V"
+  if /i not "!PROC_OK!"=="ok" (
+    echo [Junie] Removing invalid update artifact: !PROCESSING! 1>&2
+    del /f /q "!PROCESSING!" 2>nul
+  )
+)
 
 :: === Apply Pending Update ===
 if not exist "%PENDING_UPDATE%" goto :resolve_version

--- a/install-nightly.sh
+++ b/install-nightly.sh
@@ -257,6 +257,40 @@ detect_archive_type() {
   esac
 }
 
+# === Defensive Sanitization ===
+#
+# JUNIE-2957 defense: drop update artifacts that are empty or unparseable
+# BEFORE we (or the binary's own update path) act on them.
+#
+# A legitimate in-flight update writes the manifest fully and only then renames
+# it into place, so an existing `pending-update.json` or
+# `pending-update.json.processing` that is zero bytes, or that lacks the
+# required `version` / `zipPath` fields, can only be junk -- a leftover from a
+# prior crash, a partial write, or content planted by mistake. We must not feed
+# that to either `apply_pending_update` below or to the launched binary, which
+# may otherwise try to "resolve" paths derived from CWD/EJ_RUNNER_PWD.
+#
+# Best-effort: any rm failure is swallowed; the regular `apply_pending_update`
+# path will then handle the file conservatively or skip it.
+sanitize_pending_updates() {
+  [[ -d "$UPDATES_DIR" ]] || return 0
+  local f v z
+  for f in "$PENDING_UPDATE" "$UPDATES_DIR/pending-update.json.processing"; do
+    [[ -f "$f" ]] || continue
+    if [[ ! -s "$f" ]]; then
+      log_both "Removing zero-byte update artifact: $f"
+      rm -f "$f" 2>/dev/null || true
+      continue
+    fi
+    v=$(get_json_field "$f" "version")
+    z=$(get_json_field "$f" "zipPath")
+    if [[ -z "$v" || -z "$z" ]]; then
+      log_both "Removing unparseable update artifact (missing version/zipPath): $f"
+      rm -f "$f" 2>/dev/null || true
+    fi
+  done
+}
+
 # === Apply Pending Update ===
 #
 # Atomic extraction strategy:
@@ -557,6 +591,10 @@ handle_shim_commands() {
 main() {
   # Handle shim-specific commands
   handle_shim_commands "$@"
+
+  # Defense-in-depth (JUNIE-2957): drop empty / unparseable update artifacts
+  # before either we or the launched binary react to them.
+  sanitize_pending_updates
 
   # Apply pending update if present. On failure we deliberately do NOT abort:
   # the previous version is still on disk (via the `current` symlink) and should run.

--- a/templates/junie.shim.bat
+++ b/templates/junie.shim.bat
@@ -20,6 +20,33 @@ set "VERSIONS_DIR=%JUNIE_DATA%\versions"
 set "UPDATES_DIR=%JUNIE_DATA%\updates"
 set "CURRENT_FILE=%JUNIE_DATA%\current"
 set "PENDING_UPDATE=%UPDATES_DIR%\pending-update.json"
+set "PROCESSING=%UPDATES_DIR%\pending-update.json.processing"
+
+::: === Defensive Sanitization ===
+:::
+::: JUNIE-2957 defense: drop pending-update.json / pending-update.json.processing
+::: if they are empty or unparseable BEFORE the atomic-claim rename below. A
+::: legitimate in-flight update writes the manifest fully and then renames it,
+::: so a zero-byte file or one missing `version`/`zipPath` can only be junk --
+::: a leftover from a prior crash or content planted by mistake. Without this,
+::: a stale .processing blocks all future updates AND can be inherited by the
+::: binary's own update path with CWD as a working-dir hint.
+if exist "%PENDING_UPDATE%" (
+  set "PEND_OK="
+  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '%PENDING_UPDATE%' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c ^| ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PEND_OK=%%V"
+  if /i not "!PEND_OK!"=="ok" (
+    echo [Junie] Removing invalid update artifact: %PENDING_UPDATE% 1>&2
+    del /f /q "%PENDING_UPDATE%" 2>nul
+  )
+)
+if exist "!PROCESSING!" (
+  set "PROC_OK="
+  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '!PROCESSING!' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c ^| ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PROC_OK=%%V"
+  if /i not "!PROC_OK!"=="ok" (
+    echo [Junie] Removing invalid update artifact: !PROCESSING! 1>&2
+    del /f /q "!PROCESSING!" 2>nul
+  )
+)
 
 :: === Apply Pending Update ===
 if not exist "%PENDING_UPDATE%" goto :resolve_version

--- a/templates/junie.shim.sh
+++ b/templates/junie.shim.sh
@@ -130,6 +130,40 @@ detect_archive_type() {
   esac
 }
 
+# === Defensive Sanitization ===
+#
+# JUNIE-2957 defense: drop update artifacts that are empty or unparseable
+# BEFORE we (or the binary's own update path) act on them.
+#
+# A legitimate in-flight update writes the manifest fully and only then renames
+# it into place, so an existing `pending-update.json` or
+# `pending-update.json.processing` that is zero bytes, or that lacks the
+# required `version` / `zipPath` fields, can only be junk -- a leftover from a
+# prior crash, a partial write, or content planted by mistake. We must not feed
+# that to either `apply_pending_update` below or to the launched binary, which
+# may otherwise try to "resolve" paths derived from CWD/EJ_RUNNER_PWD.
+#
+# Best-effort: any rm failure is swallowed; the regular `apply_pending_update`
+# path will then handle the file conservatively or skip it.
+sanitize_pending_updates() {
+  [[ -d "$UPDATES_DIR" ]] || return 0
+  local f v z
+  for f in "$PENDING_UPDATE" "$UPDATES_DIR/pending-update.json.processing"; do
+    [[ -f "$f" ]] || continue
+    if [[ ! -s "$f" ]]; then
+      log_both "Removing zero-byte update artifact: $f"
+      rm -f "$f" 2>/dev/null || true
+      continue
+    fi
+    v=$(get_json_field "$f" "version")
+    z=$(get_json_field "$f" "zipPath")
+    if [[ -z "$v" || -z "$z" ]]; then
+      log_both "Removing unparseable update artifact (missing version/zipPath): $f"
+      rm -f "$f" 2>/dev/null || true
+    fi
+  done
+}
+
 # === Apply Pending Update ===
 #
 # Atomic extraction strategy:
@@ -430,6 +464,10 @@ handle_shim_commands() {
 main() {
   # Handle shim-specific commands
   handle_shim_commands "$@"
+
+  # Defense-in-depth (JUNIE-2957): drop empty / unparseable update artifacts
+  # before either we or the launched binary react to them.
+  sanitize_pending_updates
 
   # Apply pending update if present. On failure we deliberately do NOT abort:
   # the previous version is still on disk (via the `current` symlink) and should run.


### PR DESCRIPTION
## What

Adds defensive sanitization to the Junie CLI shim (both bash and Windows bat) so that empty or unparseable `pending-update.json` / `pending-update.json.processing` files left under `~/.local/share/junie/updates/` are dropped at startup, **before** any update logic runs and **before** the binary is launched.

Applied via `templates/junie.shim.{sh,bat}` and regenerated into `install-nightly.{sh,ps1}` and `install-experimental.{sh,ps1}`.

## Why — JUNIE-2957

[JUNIE-2957](https://youtrack.jetbrains.com/issue/JUNIE-2957/Junie-CLI-EAP-Junie-deletes-all-files-in-folder) reports that running `junie` in a directory wipes that directory’s files. The user’s repro is:

1. Create empty `~/.local/share/junie/updates/pending-update.json`
2. Create empty `~/.local/share/junie/updates/pending-update.json.processing`
3. `cd ./test` (with files in it)
4. Run `junie`

Investigation showed that the destructive `rm`/`del` is **not** in the shim itself — but the shim was happy to pass the stale/empty artifacts through to the binary, and then the binary’s own update-apply path reacts to them with `EJ_RUNNER_PWD=$(pwd)` as a working-dir hint, which is how CWD content ends up getting deleted.

Concretely:

- The **bash** shim had no concept of `pending-update.json.processing` at all, so any leftover `.processing` file was passed through unchanged.
- The **bat** shim’s atomic-claim `rename pending-update.json -> .processing` *fails* when `.processing` already exists, so a stale `.processing` was also silently left in place.

## How the fix works

At shim startup, before `apply_pending_update` (sh) and before the atomic-claim `rename` (bat), the shim now checks both `pending-update.json` and `pending-update.json.processing` and **removes** either file if:

- it is zero bytes, **or**
- it cannot be parsed as JSON with non-empty `version` and `zipPath` fields.

A legitimate in-flight update writes the manifest fully and only then renames it into place, so a 0-byte / no-`version` / no-`zipPath` artifact can only be junk: a leftover from a prior crash, a partial write, or content planted by mistake. We must not let either the shim or the launched binary act on it.

This implements recommendation #3 from the JUNIE-2957 analysis (“have the shim evict a *stale* `pending-update.json.processing` at startup so the user’s pre-seeded scenario gets normalized before the binary ever sees it”).

```mermaid
flowchart LR
  A[Shim start] --> B[sanitize_pending_updates / bat sanitize]
  B --> C[apply_pending_update]
  C --> D[exec junie binary]
  B -->|drop empty / unparseable| E[updates dir clean]
  E --> C
```

## Scope of this PR

| File | Action |
| --- | --- |
| `templates/junie.shim.sh` | Add `sanitize_pending_updates`, call from `main` before `apply_pending_update` |
| `templates/junie.shim.bat` | Add inline empty/JSON-validity check + delete for both files before the atomic-claim rename |
| `install-nightly.sh`, `install-nightly.ps1` | Regenerated from templates |
| `install-experimental.sh`, `install-experimental.ps1` | Regenerated from templates |

**Deliberately NOT included:** `install.{sh,ps1}` and `install-eap.{sh,ps1}` are left untouched. Those installer scripts in the repo are still on the *old* shim (no staging, no atomic swap), so regenerating them from the current templates would also promote the larger shim rewrite to release and EAP — out of scope for this fix. They will be promoted in a follow-up.

> ⚠️ Consequence: `./templates/generate.sh --check` will be red on `main` after this PR lands until that follow-up promotes the release/EAP installers. This is an intentional, accepted trade-off; the alternative (regenerating release/EAP here) would ship a much larger change in this PR.

## What this PR does *not* fix

The full close-out of JUNIE-2957 also needs a **binary-side** fix (recommendation #2 from the analysis):

- The Junie binary’s update-apply code should treat an empty / unparseable `pending-update.json` / `.processing` as “drop and continue”, never as “extract into something derived from CWD/`EJ_RUNNER_PWD`”.
- The binary should refuse to resolve any extraction destination outside `$JUNIE_DATA/versions/`.

Those changes live in a different repo and are out of scope here. With this shim-side sanitization in place, the user’s literal repro is neutralized for nightly/experimental users before the binary ever sees the bad state.

## Verification

- `./templates/generate.sh` regenerates all 8 installer scripts cleanly.
- `./templates/generate.sh --check` reports no drift between templates and the regenerated `nightly`/`experimental` outputs.
- `bash -n` passes for all touched `.sh` files.
- Manually validated that `apply_pending_update` no longer sees the planted empty files after `sanitize_pending_updates` runs (sh code path inspected; bat code path follows the same logic via PowerShell + `Get-Content`/`ConvertFrom-Json`).

## Risk

Low. The new logic only deletes files in `~/.local/share/junie/updates/` whose own content (or zero size) already proves they cannot be a valid manifest. No other paths are touched. In the common case where no update is pending, neither shim spawns any extra process (the sh path is a pure-bash check; the bat path skips the PowerShell call entirely when the file doesn’t exist).

## Refs

- YouTrack: [JUNIE-2957](https://youtrack.jetbrains.com/issue/JUNIE-2957/Junie-CLI-EAP-Junie-deletes-all-files-in-folder)
