### PR TITLE
Harden installer (nightly & experimental): always overwrite version + verify specific-version checksum

### DIFF
--- a/install-experimental.ps1
+++ b/install-experimental.ps1
@@ -55,12 +55,46 @@ function Fetch-LatestVersion {
   }
 }
 
+# Look up the SHA-256 checksum for a specific version+platform from the
+# update-info JSONL so that explicit JUNIE_VERSION requests can still be
+# integrity-checked. Returns the checksum if found, or an empty string otherwise.
+# Best-effort: network/parse failures or a version that isn't listed simply
+# result in an empty checksum (the caller decides how to proceed).
+function Fetch-VersionSha256($wantVersion) {
+  try {
+    $jsonl = Invoke-RestMethod -Uri $UPDATE_INFO_URL
+  } catch {
+    return ""
+  }
+
+  $lines = $jsonl -split "`n" | Where-Object { $_ -match "`"platform`":`"$PLATFORM`"" }
+  foreach ($line in $lines) {
+    try {
+      $parsed = $line | ConvertFrom-Json
+    } catch {
+      continue
+    }
+    if ($parsed.version -eq $wantVersion) {
+      return $parsed.sha256
+    }
+  }
+  return ""
+}
+
 # Determine version: use JUNIE_VERSION env var if set, otherwise fetch latest
 if ($env:JUNIE_VERSION) {
   $VERSION = $env:JUNIE_VERSION
   $DOWNLOAD_URL = "$GITHUB_RELEASES/download/$VERSION/junie-$CHANNEL-$VERSION-$PLATFORM.zip"
-  $SHA256 = ""
   Log "Using specified version: $VERSION"
+  # Even for an explicitly requested version, try to look up its published
+  # checksum so the download is still integrity-checked. If the version isn't
+  # listed in update-info we proceed without a checksum (best-effort).
+  $SHA256 = Fetch-VersionSha256 $VERSION
+  if ($SHA256) {
+    Log "Found published checksum for version $VERSION"
+  } else {
+    Log "Warning: No checksum found for version $VERSION; proceeding without integrity verification"
+  }
 } else {
   Fetch-LatestVersion
 }
@@ -73,57 +107,60 @@ New-Item -ItemType Directory -Force -Path "$JUNIE_DATA\versions" | Out-Null
 New-Item -ItemType Directory -Force -Path "$JUNIE_DATA\updates" | Out-Null
 
 # Download and install binary
+# Always re-download and overwrite the target version directory, regardless of
+# whether it already exists. This avoids reusing a previously cached broken or
+# partial install for the same version.
 $TARGET_DIR = Join-Path "$JUNIE_DATA\versions" $VERSION
 
-if (-not (Test-Path $TARGET_DIR)) {
-  $TMP_ZIP = Join-Path $env:TEMP "junie-$VERSION.zip"
+$TMP_ZIP = Join-Path $env:TEMP "junie-$VERSION.zip"
 
-  Log "Downloading $DOWNLOAD_URL"
-  $oldProgress = $ProgressPreference
-  $ProgressPreference = 'SilentlyContinue'
-  Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile $TMP_ZIP -UseBasicParsing
-  $ProgressPreference = $oldProgress
+Log "Downloading $DOWNLOAD_URL"
+$oldProgress = $ProgressPreference
+$ProgressPreference = 'SilentlyContinue'
+Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile $TMP_ZIP -UseBasicParsing
+$ProgressPreference = $oldProgress
 
-  # Verify checksum
-  if ($SHA256) {
-    $actualSha256 = Get-Sha256 $TMP_ZIP
-    if ($actualSha256 -ne $SHA256.ToLower()) {
-      Log-Error "Checksum verification failed!"
-      Log-Error "Expected: $SHA256"
-      Log-Error "Got: $actualSha256"
-      Remove-Item -Force $TMP_ZIP
-      exit 1
-    }
-    Log "Checksum verified"
+# Verify checksum
+if ($SHA256) {
+  $actualSha256 = Get-Sha256 $TMP_ZIP
+  if ($actualSha256 -ne $SHA256.ToLower()) {
+    Log-Error "Checksum verification failed!"
+    Log-Error "Expected: $SHA256"
+    Log-Error "Got: $actualSha256"
+    Remove-Item -Force $TMP_ZIP
+    exit 1
+  }
+  Log "Checksum verified"
+}
+
+# Extract to a staging dir on the same filesystem as $TARGET_DIR, validate the
+# resolved binary, then atomically rename into place. This mirrors the shim's
+# robust extraction so an interrupted install never leaves a half-extracted tree.
+$STAGING = Join-Path "$JUNIE_DATA\versions" (".$VERSION.tmp." + $PID)
+if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
+New-Item -ItemType Directory -Force -Path $STAGING | Out-Null
+
+try {
+  $oldProgress = $global:ProgressPreference
+  $global:ProgressPreference = 'SilentlyContinue'
+  Expand-Archive -Path $TMP_ZIP -DestinationPath $STAGING -Force
+  $global:ProgressPreference = $oldProgress
+
+  # Validate that the expected binary is present in the staging tree.
+  $StagedExe = Join-Path $STAGING "junie\junie.exe"
+  if (-not (Test-Path $StagedExe)) {
+    Log-Error "No junie binary found in downloaded payload"
+    exit 1
   }
 
-  # Extract to a staging dir on the same filesystem as $TARGET_DIR, validate the
-  # resolved binary, then atomically rename into place. This mirrors the shim's
-  # robust extraction so an interrupted install never leaves a half-extracted tree.
-  $STAGING = Join-Path "$JUNIE_DATA\versions" (".$VERSION.tmp." + $PID)
+  # Remove any existing (possibly broken) version directory before the rename.
+  if (Test-Path $TARGET_DIR) { Remove-Item -Recurse -Force $TARGET_DIR }
+  Move-Item -Path $STAGING -Destination $TARGET_DIR
+} catch {
   if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
-  New-Item -ItemType Directory -Force -Path $STAGING | Out-Null
-
-  try {
-    $oldProgress = $global:ProgressPreference
-    $global:ProgressPreference = 'SilentlyContinue'
-    Expand-Archive -Path $TMP_ZIP -DestinationPath $STAGING -Force
-    $global:ProgressPreference = $oldProgress
-
-    # Validate that the expected binary is present in the staging tree.
-    $StagedExe = Join-Path $STAGING "junie\junie.exe"
-    if (-not (Test-Path $StagedExe)) {
-      Log-Error "No junie binary found in downloaded payload"
-      exit 1
-    }
-
-    Move-Item -Path $STAGING -Destination $TARGET_DIR
-  } catch {
-    if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
-    throw
-  } finally {
-    Remove-Item -Force $TMP_ZIP -ErrorAction SilentlyContinue
-  }
+  throw
+} finally {
+  Remove-Item -Force $TMP_ZIP -ErrorAction SilentlyContinue
 }
 
 # Write current version pointer file (plain text, not symlink)

--- a/install-experimental.sh
+++ b/install-experimental.sh
@@ -88,6 +88,24 @@ fetch_latest_version() {
   fi
 }
 
+# Look up the SHA-256 checksum for a specific version+platform from the
+# update-info JSONL so that explicit JUNIE_VERSION requests can still be
+# integrity-checked. Echoes the checksum if found, or an empty string otherwise.
+# Best-effort: network/parse failures or a version that isn't listed simply
+# result in an empty checksum (the caller decides how to proceed).
+fetch_version_sha256() {
+  local want_version="$1"
+  local jsonl entry
+  jsonl=$(curl -fsSL "$UPDATE_INFO_URL" 2> /dev/null) || return 0
+
+  # Match the entry for the exact version (trailing quote anchors the match so
+  # "1.1" does not match "1.12") and our platform.
+  entry=$(echo "$jsonl" | grep "\"version\":\"$want_version\"" | grep "\"platform\":\"$PLATFORM\"" | tail -1)
+  [[ -z "$entry" ]] && return 0
+
+  echo "$entry" | grep -o '"sha256":"[^"]*"' | sed 's/"sha256":"\([^"]*\)"/\1/'
+}
+
 # Detect platform
 OS=$(uname -s)
 ARCH=$(uname -m)
@@ -110,8 +128,16 @@ PLATFORM="${OS_NAME}-${ARCH_NAME}"
 if [[ -n "${JUNIE_VERSION:-}" ]]; then
   VERSION="$JUNIE_VERSION"
   DOWNLOAD_URL="$GITHUB_RELEASES/download/${VERSION}/junie-${CHANNEL}-${VERSION}-${PLATFORM}.zip"
-  SHA256=""  # No checksum verification for specific version requests
   log "Using specified version: $VERSION"
+  # Even for an explicitly requested version, try to look up its published
+  # checksum so the download is still integrity-checked. If the version isn't
+  # listed in update-info we proceed without a checksum (best-effort).
+  SHA256=$(fetch_version_sha256 "$VERSION")
+  if [[ -n "$SHA256" ]]; then
+    log "Found published checksum for version $VERSION"
+  else
+    log "Warning: No checksum found for version $VERSION; proceeding without integrity verification"
+  fi
 else
   fetch_latest_version
 fi
@@ -632,64 +658,67 @@ SHIM_EOF
 chmod +x "$JUNIE_BIN/junie"
 
 # Download and install binary
+# Always re-download and overwrite the target version directory, regardless of
+# whether it already exists. This avoids reusing a previously cached broken or
+# partial install for the same version.
 TARGET_DIR="$JUNIE_DATA/versions/$VERSION"
-if [[ ! -d "$TARGET_DIR" ]]; then
-  TMP_ZIP=$(mktemp)
+TMP_ZIP=$(mktemp)
 
-  log "Downloading $DOWNLOAD_URL"
-  curl -fSL --progress-bar -o "$TMP_ZIP" "$DOWNLOAD_URL"
+log "Downloading $DOWNLOAD_URL"
+curl -fSL --progress-bar -o "$TMP_ZIP" "$DOWNLOAD_URL"
 
-  # Verify checksum
-  if [[ -n "$SHA256" ]]; then
-    actual_sha256=$(sha256sum_file "$TMP_ZIP")
-    if [[ -n "$actual_sha256" ]]; then
-      if ! echo "$actual_sha256" | grep -qi "^${SHA256}$"; then
-        log_error "Checksum verification failed!"
-        log_error "Expected: $SHA256"
-        log_error "Got: $actual_sha256"
-        rm -f "$TMP_ZIP"
-        exit 1
-      fi
-      log "Checksum verified"
+# Verify checksum
+if [[ -n "$SHA256" ]]; then
+  actual_sha256=$(sha256sum_file "$TMP_ZIP")
+  if [[ -n "$actual_sha256" ]]; then
+    if ! echo "$actual_sha256" | grep -qi "^${SHA256}$"; then
+      log_error "Checksum verification failed!"
+      log_error "Expected: $SHA256"
+      log_error "Got: $actual_sha256"
+      rm -f "$TMP_ZIP"
+      exit 1
     fi
+    log "Checksum verified"
   fi
-
-  # Extract to a staging dir on the same filesystem as $TARGET_DIR, validate the
-  # resolved binary, then atomically rename into place. This mirrors the shim's
-  # robust extraction so an interrupted install never leaves a half-extracted tree.
-  STAGING="$JUNIE_DATA/versions/.$VERSION.tmp.$$"
-  trap 'rm -rf "$STAGING"' EXIT INT TERM
-  rm -rf "$STAGING"
-  mkdir -p "$STAGING"
-  unzip -q "$TMP_ZIP" -d "$STAGING"
-  rm -f "$TMP_ZIP"
-
-  # Validate the extracted binary (inline equivalent of get_binary_path_in).
-  if [[ -d "$STAGING/Applications/junie.app" ]]; then
-    STAGED_BIN="$STAGING/Applications/junie.app/Contents/MacOS/junie"
-  elif [[ -f "$STAGING/junie/bin/junie" ]]; then
-    STAGED_BIN="$STAGING/junie/bin/junie"
-  elif [[ -f "$STAGING/junie" ]]; then
-    STAGED_BIN="$STAGING/junie"
-  else
-    STAGED_BIN=""
-  fi
-  if [[ -z "$STAGED_BIN" ]]; then
-    log_error "No junie binary found in downloaded payload"
-    exit 1
-  fi
-  chmod +x "$STAGED_BIN" 2>/dev/null || true
-  if [[ ! -x "$STAGED_BIN" ]]; then
-    log_error "Extracted binary is not executable: $STAGED_BIN"
-    exit 1
-  fi
-
-  [[ "$OS_NAME" == "macos" ]] && xattr -dr com.apple.quarantine "$STAGING" 2>/dev/null || true
-
-  # Atomic rename into the final version directory.
-  mv "$STAGING" "$TARGET_DIR"
-  trap - EXIT INT TERM
 fi
+
+# Extract to a staging dir on the same filesystem as $TARGET_DIR, validate the
+# resolved binary, then atomically rename into place. This mirrors the shim's
+# robust extraction so an interrupted install never leaves a half-extracted tree.
+STAGING="$JUNIE_DATA/versions/.$VERSION.tmp.$$"
+trap 'rm -rf "$STAGING"' EXIT INT TERM
+rm -rf "$STAGING"
+mkdir -p "$STAGING"
+unzip -q "$TMP_ZIP" -d "$STAGING"
+rm -f "$TMP_ZIP"
+
+# Validate the extracted binary (inline equivalent of get_binary_path_in).
+if [[ -d "$STAGING/Applications/junie.app" ]]; then
+  STAGED_BIN="$STAGING/Applications/junie.app/Contents/MacOS/junie"
+elif [[ -f "$STAGING/junie/bin/junie" ]]; then
+  STAGED_BIN="$STAGING/junie/bin/junie"
+elif [[ -f "$STAGING/junie" ]]; then
+  STAGED_BIN="$STAGING/junie"
+else
+  STAGED_BIN=""
+fi
+if [[ -z "$STAGED_BIN" ]]; then
+  log_error "No junie binary found in downloaded payload"
+  exit 1
+fi
+chmod +x "$STAGED_BIN" 2>/dev/null || true
+if [[ ! -x "$STAGED_BIN" ]]; then
+  log_error "Extracted binary is not executable: $STAGED_BIN"
+  exit 1
+fi
+
+[[ "$OS_NAME" == "macos" ]] && xattr -dr com.apple.quarantine "$STAGING" 2>/dev/null || true
+
+# Remove any existing (possibly broken) version directory, then atomically
+# rename the validated staging tree into the final version directory.
+rm -rf "$TARGET_DIR"
+mv "$STAGING" "$TARGET_DIR"
+trap - EXIT INT TERM
 
 # Set current version
 ln -sfn "$TARGET_DIR" "$JUNIE_DATA/current"

--- a/install-nightly.ps1
+++ b/install-nightly.ps1
@@ -55,12 +55,46 @@ function Fetch-LatestVersion {
   }
 }
 
+# Look up the SHA-256 checksum for a specific version+platform from the
+# update-info JSONL so that explicit JUNIE_VERSION requests can still be
+# integrity-checked. Returns the checksum if found, or an empty string otherwise.
+# Best-effort: network/parse failures or a version that isn't listed simply
+# result in an empty checksum (the caller decides how to proceed).
+function Fetch-VersionSha256($wantVersion) {
+  try {
+    $jsonl = Invoke-RestMethod -Uri $UPDATE_INFO_URL
+  } catch {
+    return ""
+  }
+
+  $lines = $jsonl -split "`n" | Where-Object { $_ -match "`"platform`":`"$PLATFORM`"" }
+  foreach ($line in $lines) {
+    try {
+      $parsed = $line | ConvertFrom-Json
+    } catch {
+      continue
+    }
+    if ($parsed.version -eq $wantVersion) {
+      return $parsed.sha256
+    }
+  }
+  return ""
+}
+
 # Determine version: use JUNIE_VERSION env var if set, otherwise fetch latest
 if ($env:JUNIE_VERSION) {
   $VERSION = $env:JUNIE_VERSION
   $DOWNLOAD_URL = "$GITHUB_RELEASES/download/$VERSION/junie-$CHANNEL-$VERSION-$PLATFORM.zip"
-  $SHA256 = ""
   Log "Using specified version: $VERSION"
+  # Even for an explicitly requested version, try to look up its published
+  # checksum so the download is still integrity-checked. If the version isn't
+  # listed in update-info we proceed without a checksum (best-effort).
+  $SHA256 = Fetch-VersionSha256 $VERSION
+  if ($SHA256) {
+    Log "Found published checksum for version $VERSION"
+  } else {
+    Log "Warning: No checksum found for version $VERSION; proceeding without integrity verification"
+  }
 } else {
   Fetch-LatestVersion
 }
@@ -73,57 +107,60 @@ New-Item -ItemType Directory -Force -Path "$JUNIE_DATA\versions" | Out-Null
 New-Item -ItemType Directory -Force -Path "$JUNIE_DATA\updates" | Out-Null
 
 # Download and install binary
+# Always re-download and overwrite the target version directory, regardless of
+# whether it already exists. This avoids reusing a previously cached broken or
+# partial install for the same version.
 $TARGET_DIR = Join-Path "$JUNIE_DATA\versions" $VERSION
 
-if (-not (Test-Path $TARGET_DIR)) {
-  $TMP_ZIP = Join-Path $env:TEMP "junie-$VERSION.zip"
+$TMP_ZIP = Join-Path $env:TEMP "junie-$VERSION.zip"
 
-  Log "Downloading $DOWNLOAD_URL"
-  $oldProgress = $ProgressPreference
-  $ProgressPreference = 'SilentlyContinue'
-  Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile $TMP_ZIP -UseBasicParsing
-  $ProgressPreference = $oldProgress
+Log "Downloading $DOWNLOAD_URL"
+$oldProgress = $ProgressPreference
+$ProgressPreference = 'SilentlyContinue'
+Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile $TMP_ZIP -UseBasicParsing
+$ProgressPreference = $oldProgress
 
-  # Verify checksum
-  if ($SHA256) {
-    $actualSha256 = Get-Sha256 $TMP_ZIP
-    if ($actualSha256 -ne $SHA256.ToLower()) {
-      Log-Error "Checksum verification failed!"
-      Log-Error "Expected: $SHA256"
-      Log-Error "Got: $actualSha256"
-      Remove-Item -Force $TMP_ZIP
-      exit 1
-    }
-    Log "Checksum verified"
+# Verify checksum
+if ($SHA256) {
+  $actualSha256 = Get-Sha256 $TMP_ZIP
+  if ($actualSha256 -ne $SHA256.ToLower()) {
+    Log-Error "Checksum verification failed!"
+    Log-Error "Expected: $SHA256"
+    Log-Error "Got: $actualSha256"
+    Remove-Item -Force $TMP_ZIP
+    exit 1
+  }
+  Log "Checksum verified"
+}
+
+# Extract to a staging dir on the same filesystem as $TARGET_DIR, validate the
+# resolved binary, then atomically rename into place. This mirrors the shim's
+# robust extraction so an interrupted install never leaves a half-extracted tree.
+$STAGING = Join-Path "$JUNIE_DATA\versions" (".$VERSION.tmp." + $PID)
+if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
+New-Item -ItemType Directory -Force -Path $STAGING | Out-Null
+
+try {
+  $oldProgress = $global:ProgressPreference
+  $global:ProgressPreference = 'SilentlyContinue'
+  Expand-Archive -Path $TMP_ZIP -DestinationPath $STAGING -Force
+  $global:ProgressPreference = $oldProgress
+
+  # Validate that the expected binary is present in the staging tree.
+  $StagedExe = Join-Path $STAGING "junie\junie.exe"
+  if (-not (Test-Path $StagedExe)) {
+    Log-Error "No junie binary found in downloaded payload"
+    exit 1
   }
 
-  # Extract to a staging dir on the same filesystem as $TARGET_DIR, validate the
-  # resolved binary, then atomically rename into place. This mirrors the shim's
-  # robust extraction so an interrupted install never leaves a half-extracted tree.
-  $STAGING = Join-Path "$JUNIE_DATA\versions" (".$VERSION.tmp." + $PID)
+  # Remove any existing (possibly broken) version directory before the rename.
+  if (Test-Path $TARGET_DIR) { Remove-Item -Recurse -Force $TARGET_DIR }
+  Move-Item -Path $STAGING -Destination $TARGET_DIR
+} catch {
   if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
-  New-Item -ItemType Directory -Force -Path $STAGING | Out-Null
-
-  try {
-    $oldProgress = $global:ProgressPreference
-    $global:ProgressPreference = 'SilentlyContinue'
-    Expand-Archive -Path $TMP_ZIP -DestinationPath $STAGING -Force
-    $global:ProgressPreference = $oldProgress
-
-    # Validate that the expected binary is present in the staging tree.
-    $StagedExe = Join-Path $STAGING "junie\junie.exe"
-    if (-not (Test-Path $StagedExe)) {
-      Log-Error "No junie binary found in downloaded payload"
-      exit 1
-    }
-
-    Move-Item -Path $STAGING -Destination $TARGET_DIR
-  } catch {
-    if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
-    throw
-  } finally {
-    Remove-Item -Force $TMP_ZIP -ErrorAction SilentlyContinue
-  }
+  throw
+} finally {
+  Remove-Item -Force $TMP_ZIP -ErrorAction SilentlyContinue
 }
 
 # Write current version pointer file (plain text, not symlink)

--- a/install-nightly.sh
+++ b/install-nightly.sh
@@ -88,6 +88,24 @@ fetch_latest_version() {
   fi
 }
 
+# Look up the SHA-256 checksum for a specific version+platform from the
+# update-info JSONL so that explicit JUNIE_VERSION requests can still be
+# integrity-checked. Echoes the checksum if found, or an empty string otherwise.
+# Best-effort: network/parse failures or a version that isn't listed simply
+# result in an empty checksum (the caller decides how to proceed).
+fetch_version_sha256() {
+  local want_version="$1"
+  local jsonl entry
+  jsonl=$(curl -fsSL "$UPDATE_INFO_URL" 2> /dev/null) || return 0
+
+  # Match the entry for the exact version (trailing quote anchors the match so
+  # "1.1" does not match "1.12") and our platform.
+  entry=$(echo "$jsonl" | grep "\"version\":\"$want_version\"" | grep "\"platform\":\"$PLATFORM\"" | tail -1)
+  [[ -z "$entry" ]] && return 0
+
+  echo "$entry" | grep -o '"sha256":"[^"]*"' | sed 's/"sha256":"\([^"]*\)"/\1/'
+}
+
 # Detect platform
 OS=$(uname -s)
 ARCH=$(uname -m)
@@ -110,8 +128,16 @@ PLATFORM="${OS_NAME}-${ARCH_NAME}"
 if [[ -n "${JUNIE_VERSION:-}" ]]; then
   VERSION="$JUNIE_VERSION"
   DOWNLOAD_URL="$GITHUB_RELEASES/download/${VERSION}/junie-${CHANNEL}-${VERSION}-${PLATFORM}.zip"
-  SHA256=""  # No checksum verification for specific version requests
   log "Using specified version: $VERSION"
+  # Even for an explicitly requested version, try to look up its published
+  # checksum so the download is still integrity-checked. If the version isn't
+  # listed in update-info we proceed without a checksum (best-effort).
+  SHA256=$(fetch_version_sha256 "$VERSION")
+  if [[ -n "$SHA256" ]]; then
+    log "Found published checksum for version $VERSION"
+  else
+    log "Warning: No checksum found for version $VERSION; proceeding without integrity verification"
+  fi
 else
   fetch_latest_version
 fi
@@ -632,64 +658,67 @@ SHIM_EOF
 chmod +x "$JUNIE_BIN/junie"
 
 # Download and install binary
+# Always re-download and overwrite the target version directory, regardless of
+# whether it already exists. This avoids reusing a previously cached broken or
+# partial install for the same version.
 TARGET_DIR="$JUNIE_DATA/versions/$VERSION"
-if [[ ! -d "$TARGET_DIR" ]]; then
-  TMP_ZIP=$(mktemp)
+TMP_ZIP=$(mktemp)
 
-  log "Downloading $DOWNLOAD_URL"
-  curl -fSL --progress-bar -o "$TMP_ZIP" "$DOWNLOAD_URL"
+log "Downloading $DOWNLOAD_URL"
+curl -fSL --progress-bar -o "$TMP_ZIP" "$DOWNLOAD_URL"
 
-  # Verify checksum
-  if [[ -n "$SHA256" ]]; then
-    actual_sha256=$(sha256sum_file "$TMP_ZIP")
-    if [[ -n "$actual_sha256" ]]; then
-      if ! echo "$actual_sha256" | grep -qi "^${SHA256}$"; then
-        log_error "Checksum verification failed!"
-        log_error "Expected: $SHA256"
-        log_error "Got: $actual_sha256"
-        rm -f "$TMP_ZIP"
-        exit 1
-      fi
-      log "Checksum verified"
+# Verify checksum
+if [[ -n "$SHA256" ]]; then
+  actual_sha256=$(sha256sum_file "$TMP_ZIP")
+  if [[ -n "$actual_sha256" ]]; then
+    if ! echo "$actual_sha256" | grep -qi "^${SHA256}$"; then
+      log_error "Checksum verification failed!"
+      log_error "Expected: $SHA256"
+      log_error "Got: $actual_sha256"
+      rm -f "$TMP_ZIP"
+      exit 1
     fi
+    log "Checksum verified"
   fi
-
-  # Extract to a staging dir on the same filesystem as $TARGET_DIR, validate the
-  # resolved binary, then atomically rename into place. This mirrors the shim's
-  # robust extraction so an interrupted install never leaves a half-extracted tree.
-  STAGING="$JUNIE_DATA/versions/.$VERSION.tmp.$$"
-  trap 'rm -rf "$STAGING"' EXIT INT TERM
-  rm -rf "$STAGING"
-  mkdir -p "$STAGING"
-  unzip -q "$TMP_ZIP" -d "$STAGING"
-  rm -f "$TMP_ZIP"
-
-  # Validate the extracted binary (inline equivalent of get_binary_path_in).
-  if [[ -d "$STAGING/Applications/junie.app" ]]; then
-    STAGED_BIN="$STAGING/Applications/junie.app/Contents/MacOS/junie"
-  elif [[ -f "$STAGING/junie/bin/junie" ]]; then
-    STAGED_BIN="$STAGING/junie/bin/junie"
-  elif [[ -f "$STAGING/junie" ]]; then
-    STAGED_BIN="$STAGING/junie"
-  else
-    STAGED_BIN=""
-  fi
-  if [[ -z "$STAGED_BIN" ]]; then
-    log_error "No junie binary found in downloaded payload"
-    exit 1
-  fi
-  chmod +x "$STAGED_BIN" 2>/dev/null || true
-  if [[ ! -x "$STAGED_BIN" ]]; then
-    log_error "Extracted binary is not executable: $STAGED_BIN"
-    exit 1
-  fi
-
-  [[ "$OS_NAME" == "macos" ]] && xattr -dr com.apple.quarantine "$STAGING" 2>/dev/null || true
-
-  # Atomic rename into the final version directory.
-  mv "$STAGING" "$TARGET_DIR"
-  trap - EXIT INT TERM
 fi
+
+# Extract to a staging dir on the same filesystem as $TARGET_DIR, validate the
+# resolved binary, then atomically rename into place. This mirrors the shim's
+# robust extraction so an interrupted install never leaves a half-extracted tree.
+STAGING="$JUNIE_DATA/versions/.$VERSION.tmp.$$"
+trap 'rm -rf "$STAGING"' EXIT INT TERM
+rm -rf "$STAGING"
+mkdir -p "$STAGING"
+unzip -q "$TMP_ZIP" -d "$STAGING"
+rm -f "$TMP_ZIP"
+
+# Validate the extracted binary (inline equivalent of get_binary_path_in).
+if [[ -d "$STAGING/Applications/junie.app" ]]; then
+  STAGED_BIN="$STAGING/Applications/junie.app/Contents/MacOS/junie"
+elif [[ -f "$STAGING/junie/bin/junie" ]]; then
+  STAGED_BIN="$STAGING/junie/bin/junie"
+elif [[ -f "$STAGING/junie" ]]; then
+  STAGED_BIN="$STAGING/junie"
+else
+  STAGED_BIN=""
+fi
+if [[ -z "$STAGED_BIN" ]]; then
+  log_error "No junie binary found in downloaded payload"
+  exit 1
+fi
+chmod +x "$STAGED_BIN" 2>/dev/null || true
+if [[ ! -x "$STAGED_BIN" ]]; then
+  log_error "Extracted binary is not executable: $STAGED_BIN"
+  exit 1
+fi
+
+[[ "$OS_NAME" == "macos" ]] && xattr -dr com.apple.quarantine "$STAGING" 2>/dev/null || true
+
+# Remove any existing (possibly broken) version directory, then atomically
+# rename the validated staging tree into the final version directory.
+rm -rf "$TARGET_DIR"
+mv "$STAGING" "$TARGET_DIR"
+trap - EXIT INT TERM
 
 # Set current version
 ln -sfn "$TARGET_DIR" "$JUNIE_DATA/current"

--- a/templates/install.ps1.template
+++ b/templates/install.ps1.template
@@ -54,12 +54,46 @@ function Fetch-LatestVersion {
   }
 }
 
+# Look up the SHA-256 checksum for a specific version+platform from the
+# update-info JSONL so that explicit JUNIE_VERSION requests can still be
+# integrity-checked. Returns the checksum if found, or an empty string otherwise.
+# Best-effort: network/parse failures or a version that isn't listed simply
+# result in an empty checksum (the caller decides how to proceed).
+function Fetch-VersionSha256($wantVersion) {
+  try {
+    $jsonl = Invoke-RestMethod -Uri $UPDATE_INFO_URL
+  } catch {
+    return ""
+  }
+
+  $lines = $jsonl -split "`n" | Where-Object { $_ -match "`"platform`":`"$PLATFORM`"" }
+  foreach ($line in $lines) {
+    try {
+      $parsed = $line | ConvertFrom-Json
+    } catch {
+      continue
+    }
+    if ($parsed.version -eq $wantVersion) {
+      return $parsed.sha256
+    }
+  }
+  return ""
+}
+
 # Determine version: use JUNIE_VERSION env var if set, otherwise fetch latest
 if ($env:JUNIE_VERSION) {
   $VERSION = $env:JUNIE_VERSION
   $DOWNLOAD_URL = "$GITHUB_RELEASES/download/$VERSION/junie-$CHANNEL-$VERSION-$PLATFORM.zip"
-  $SHA256 = ""
   Log "Using specified version: $VERSION"
+  # Even for an explicitly requested version, try to look up its published
+  # checksum so the download is still integrity-checked. If the version isn't
+  # listed in update-info we proceed without a checksum (best-effort).
+  $SHA256 = Fetch-VersionSha256 $VERSION
+  if ($SHA256) {
+    Log "Found published checksum for version $VERSION"
+  } else {
+    Log "Warning: No checksum found for version $VERSION; proceeding without integrity verification"
+  }
 } else {
   Fetch-LatestVersion
 }
@@ -72,57 +106,60 @@ New-Item -ItemType Directory -Force -Path "$JUNIE_DATA\versions" | Out-Null
 New-Item -ItemType Directory -Force -Path "$JUNIE_DATA\updates" | Out-Null
 
 # Download and install binary
+# Always re-download and overwrite the target version directory, regardless of
+# whether it already exists. This avoids reusing a previously cached broken or
+# partial install for the same version.
 $TARGET_DIR = Join-Path "$JUNIE_DATA\versions" $VERSION
 
-if (-not (Test-Path $TARGET_DIR)) {
-  $TMP_ZIP = Join-Path $env:TEMP "junie-$VERSION.zip"
+$TMP_ZIP = Join-Path $env:TEMP "junie-$VERSION.zip"
 
-  Log "Downloading $DOWNLOAD_URL"
-  $oldProgress = $ProgressPreference
-  $ProgressPreference = 'SilentlyContinue'
-  Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile $TMP_ZIP -UseBasicParsing
-  $ProgressPreference = $oldProgress
+Log "Downloading $DOWNLOAD_URL"
+$oldProgress = $ProgressPreference
+$ProgressPreference = 'SilentlyContinue'
+Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile $TMP_ZIP -UseBasicParsing
+$ProgressPreference = $oldProgress
 
-  # Verify checksum
-  if ($SHA256) {
-    $actualSha256 = Get-Sha256 $TMP_ZIP
-    if ($actualSha256 -ne $SHA256.ToLower()) {
-      Log-Error "Checksum verification failed!"
-      Log-Error "Expected: $SHA256"
-      Log-Error "Got: $actualSha256"
-      Remove-Item -Force $TMP_ZIP
-      exit 1
-    }
-    Log "Checksum verified"
+# Verify checksum
+if ($SHA256) {
+  $actualSha256 = Get-Sha256 $TMP_ZIP
+  if ($actualSha256 -ne $SHA256.ToLower()) {
+    Log-Error "Checksum verification failed!"
+    Log-Error "Expected: $SHA256"
+    Log-Error "Got: $actualSha256"
+    Remove-Item -Force $TMP_ZIP
+    exit 1
+  }
+  Log "Checksum verified"
+}
+
+# Extract to a staging dir on the same filesystem as $TARGET_DIR, validate the
+# resolved binary, then atomically rename into place. This mirrors the shim's
+# robust extraction so an interrupted install never leaves a half-extracted tree.
+$STAGING = Join-Path "$JUNIE_DATA\versions" (".$VERSION.tmp." + $PID)
+if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
+New-Item -ItemType Directory -Force -Path $STAGING | Out-Null
+
+try {
+  $oldProgress = $global:ProgressPreference
+  $global:ProgressPreference = 'SilentlyContinue'
+  Expand-Archive -Path $TMP_ZIP -DestinationPath $STAGING -Force
+  $global:ProgressPreference = $oldProgress
+
+  # Validate that the expected binary is present in the staging tree.
+  $StagedExe = Join-Path $STAGING "junie\junie.exe"
+  if (-not (Test-Path $StagedExe)) {
+    Log-Error "No junie binary found in downloaded payload"
+    exit 1
   }
 
-  # Extract to a staging dir on the same filesystem as $TARGET_DIR, validate the
-  # resolved binary, then atomically rename into place. This mirrors the shim's
-  # robust extraction so an interrupted install never leaves a half-extracted tree.
-  $STAGING = Join-Path "$JUNIE_DATA\versions" (".$VERSION.tmp." + $PID)
+  # Remove any existing (possibly broken) version directory before the rename.
+  if (Test-Path $TARGET_DIR) { Remove-Item -Recurse -Force $TARGET_DIR }
+  Move-Item -Path $STAGING -Destination $TARGET_DIR
+} catch {
   if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
-  New-Item -ItemType Directory -Force -Path $STAGING | Out-Null
-
-  try {
-    $oldProgress = $global:ProgressPreference
-    $global:ProgressPreference = 'SilentlyContinue'
-    Expand-Archive -Path $TMP_ZIP -DestinationPath $STAGING -Force
-    $global:ProgressPreference = $oldProgress
-
-    # Validate that the expected binary is present in the staging tree.
-    $StagedExe = Join-Path $STAGING "junie\junie.exe"
-    if (-not (Test-Path $StagedExe)) {
-      Log-Error "No junie binary found in downloaded payload"
-      exit 1
-    }
-
-    Move-Item -Path $STAGING -Destination $TARGET_DIR
-  } catch {
-    if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
-    throw
-  } finally {
-    Remove-Item -Force $TMP_ZIP -ErrorAction SilentlyContinue
-  }
+  throw
+} finally {
+  Remove-Item -Force $TMP_ZIP -ErrorAction SilentlyContinue
 }
 
 # Write current version pointer file (plain text, not symlink)

--- a/templates/install.sh.template
+++ b/templates/install.sh.template
@@ -87,6 +87,24 @@ fetch_latest_version() {
   fi
 }
 
+# Look up the SHA-256 checksum for a specific version+platform from the
+# update-info JSONL so that explicit JUNIE_VERSION requests can still be
+# integrity-checked. Echoes the checksum if found, or an empty string otherwise.
+# Best-effort: network/parse failures or a version that isn't listed simply
+# result in an empty checksum (the caller decides how to proceed).
+fetch_version_sha256() {
+  local want_version="$1"
+  local jsonl entry
+  jsonl=$(curl -fsSL "$UPDATE_INFO_URL" 2> /dev/null) || return 0
+
+  # Match the entry for the exact version (trailing quote anchors the match so
+  # "1.1" does not match "1.12") and our platform.
+  entry=$(echo "$jsonl" | grep "\"version\":\"$want_version\"" | grep "\"platform\":\"$PLATFORM\"" | tail -1)
+  [[ -z "$entry" ]] && return 0
+
+  echo "$entry" | grep -o '"sha256":"[^"]*"' | sed 's/"sha256":"\([^"]*\)"/\1/'
+}
+
 # Detect platform
 OS=$(uname -s)
 ARCH=$(uname -m)
@@ -109,8 +127,16 @@ PLATFORM="${OS_NAME}-${ARCH_NAME}"
 if [[ -n "${JUNIE_VERSION:-}" ]]; then
   VERSION="$JUNIE_VERSION"
   DOWNLOAD_URL="$GITHUB_RELEASES/download/${VERSION}/junie-${CHANNEL}-${VERSION}-${PLATFORM}.zip"
-  SHA256=""  # No checksum verification for specific version requests
   log "Using specified version: $VERSION"
+  # Even for an explicitly requested version, try to look up its published
+  # checksum so the download is still integrity-checked. If the version isn't
+  # listed in update-info we proceed without a checksum (best-effort).
+  SHA256=$(fetch_version_sha256 "$VERSION")
+  if [[ -n "$SHA256" ]]; then
+    log "Found published checksum for version $VERSION"
+  else
+    log "Warning: No checksum found for version $VERSION; proceeding without integrity verification"
+  fi
 else
   fetch_latest_version
 fi
@@ -129,64 +155,67 @@ SHIM_EOF
 chmod +x "$JUNIE_BIN/junie"
 
 # Download and install binary
+# Always re-download and overwrite the target version directory, regardless of
+# whether it already exists. This avoids reusing a previously cached broken or
+# partial install for the same version.
 TARGET_DIR="$JUNIE_DATA/versions/$VERSION"
-if [[ ! -d "$TARGET_DIR" ]]; then
-  TMP_ZIP=$(mktemp)
+TMP_ZIP=$(mktemp)
 
-  log "Downloading $DOWNLOAD_URL"
-  curl -fSL --progress-bar -o "$TMP_ZIP" "$DOWNLOAD_URL"
+log "Downloading $DOWNLOAD_URL"
+curl -fSL --progress-bar -o "$TMP_ZIP" "$DOWNLOAD_URL"
 
-  # Verify checksum
-  if [[ -n "$SHA256" ]]; then
-    actual_sha256=$(sha256sum_file "$TMP_ZIP")
-    if [[ -n "$actual_sha256" ]]; then
-      if ! echo "$actual_sha256" | grep -qi "^${SHA256}$"; then
-        log_error "Checksum verification failed!"
-        log_error "Expected: $SHA256"
-        log_error "Got: $actual_sha256"
-        rm -f "$TMP_ZIP"
-        exit 1
-      fi
-      log "Checksum verified"
+# Verify checksum
+if [[ -n "$SHA256" ]]; then
+  actual_sha256=$(sha256sum_file "$TMP_ZIP")
+  if [[ -n "$actual_sha256" ]]; then
+    if ! echo "$actual_sha256" | grep -qi "^${SHA256}$"; then
+      log_error "Checksum verification failed!"
+      log_error "Expected: $SHA256"
+      log_error "Got: $actual_sha256"
+      rm -f "$TMP_ZIP"
+      exit 1
     fi
+    log "Checksum verified"
   fi
-
-  # Extract to a staging dir on the same filesystem as $TARGET_DIR, validate the
-  # resolved binary, then atomically rename into place. This mirrors the shim's
-  # robust extraction so an interrupted install never leaves a half-extracted tree.
-  STAGING="$JUNIE_DATA/versions/.$VERSION.tmp.$$"
-  trap 'rm -rf "$STAGING"' EXIT INT TERM
-  rm -rf "$STAGING"
-  mkdir -p "$STAGING"
-  unzip -q "$TMP_ZIP" -d "$STAGING"
-  rm -f "$TMP_ZIP"
-
-  # Validate the extracted binary (inline equivalent of get_binary_path_in).
-  if [[ -d "$STAGING/Applications/junie.app" ]]; then
-    STAGED_BIN="$STAGING/Applications/junie.app/Contents/MacOS/junie"
-  elif [[ -f "$STAGING/junie/bin/junie" ]]; then
-    STAGED_BIN="$STAGING/junie/bin/junie"
-  elif [[ -f "$STAGING/junie" ]]; then
-    STAGED_BIN="$STAGING/junie"
-  else
-    STAGED_BIN=""
-  fi
-  if [[ -z "$STAGED_BIN" ]]; then
-    log_error "No junie binary found in downloaded payload"
-    exit 1
-  fi
-  chmod +x "$STAGED_BIN" 2>/dev/null || true
-  if [[ ! -x "$STAGED_BIN" ]]; then
-    log_error "Extracted binary is not executable: $STAGED_BIN"
-    exit 1
-  fi
-
-  [[ "$OS_NAME" == "macos" ]] && xattr -dr com.apple.quarantine "$STAGING" 2>/dev/null || true
-
-  # Atomic rename into the final version directory.
-  mv "$STAGING" "$TARGET_DIR"
-  trap - EXIT INT TERM
 fi
+
+# Extract to a staging dir on the same filesystem as $TARGET_DIR, validate the
+# resolved binary, then atomically rename into place. This mirrors the shim's
+# robust extraction so an interrupted install never leaves a half-extracted tree.
+STAGING="$JUNIE_DATA/versions/.$VERSION.tmp.$$"
+trap 'rm -rf "$STAGING"' EXIT INT TERM
+rm -rf "$STAGING"
+mkdir -p "$STAGING"
+unzip -q "$TMP_ZIP" -d "$STAGING"
+rm -f "$TMP_ZIP"
+
+# Validate the extracted binary (inline equivalent of get_binary_path_in).
+if [[ -d "$STAGING/Applications/junie.app" ]]; then
+  STAGED_BIN="$STAGING/Applications/junie.app/Contents/MacOS/junie"
+elif [[ -f "$STAGING/junie/bin/junie" ]]; then
+  STAGED_BIN="$STAGING/junie/bin/junie"
+elif [[ -f "$STAGING/junie" ]]; then
+  STAGED_BIN="$STAGING/junie"
+else
+  STAGED_BIN=""
+fi
+if [[ -z "$STAGED_BIN" ]]; then
+  log_error "No junie binary found in downloaded payload"
+  exit 1
+fi
+chmod +x "$STAGED_BIN" 2>/dev/null || true
+if [[ ! -x "$STAGED_BIN" ]]; then
+  log_error "Extracted binary is not executable: $STAGED_BIN"
+  exit 1
+fi
+
+[[ "$OS_NAME" == "macos" ]] && xattr -dr com.apple.quarantine "$STAGING" 2>/dev/null || true
+
+# Remove any existing (possibly broken) version directory, then atomically
+# rename the validated staging tree into the final version directory.
+rm -rf "$TARGET_DIR"
+mv "$STAGING" "$TARGET_DIR"
+trap - EXIT INT TERM
 
 # Set current version
 ln -sfn "$TARGET_DIR" "$JUNIE_DATA/current"


### PR DESCRIPTION
## What & why

Two installer robustness fixes, scoped to the **nightly** and **experimental** channels only.

A user hit a broken `curl | bash` install: a corrupt/empty cached version directory was reused on every subsequent run, and explicit `JUNIE_VERSION=` installs skipped integrity verification entirely (`SHA256=""`). This PR addresses both:

1. **Always overwrite the version directory.** The download/extract no longer short-circuits when `versions/<VERSION>` already exists. The validated payload is staged and then `rm -rf` + atomically moved into place, so a previously cached broken/partial install for the same version is never reused.
2. **Verify checksum for explicit versions too.** For `JUNIE_VERSION=` requests we now look up the published `sha256` for the exact version+platform from `update-info*.jsonl` and verify it (best-effort: if the version isn't listed, we warn and proceed).

## Scope

- Changes live in the shared templates (`templates/install.sh.template`, `templates/install.ps1.template`) — the source of truth.
- Only the **nightly** and **experimental** generated scripts are regenerated/committed:
  - `install-nightly.sh`, `install-nightly.ps1`
  - `install-experimental.sh`, `install-experimental.ps1`
- **`release` (`install.sh`/`install.ps1`) and `eap` (`install-eap.*`) are intentionally left unchanged** so the fix can bake on the pre-release channels first.

> Note: because the templates carry the fix but release/eap scripts are intentionally not regenerated, `./templates/generate.sh --check` will report those two channels as out of date. This is expected for this staged rollout.

## Verification

- `bash -n` passes for `install-nightly.sh` and `install-experimental.sh`.
- Confirmed the PR diff contains only the robustness changes (no unrelated channel/arch changes).

```mermaid
flowchart TD
    A[install.sh.template] -->|generate.sh| B[install-nightly.sh]
    A -->|generate.sh| C[install-experimental.sh]
    D[install.ps1.template] -->|generate.sh| E[install-nightly.ps1]
    D -->|generate.sh| F[install-experimental.ps1]
    A -->|always rm -rf TARGET then mv + verify sha256| B
```
