### PR TITLE
Use ditto instead of unzip to extract macOS .app bundles

### DIFF
--- a/install-eap.sh
+++ b/install-eap.sh
@@ -19,18 +19,30 @@ JUNIE_DATA="$HOME/.local/share/junie"
 log() { echo "[Junie] $*"; }
 log_error() { echo "[Junie] ERROR: $*" >&2; }
 
-# Ensure required tools are available before we start downloading anything.
-# We fail early with an actionable, OS-aware install hint so users on minimal
-# images (containers, fresh VPS, etc.) aren't stuck staring at a cryptic
-# `unzip: command not found` halfway through the install.
-require_unzip() {
+# Ensure the required archive extractor is available before we start downloading
+# anything. We fail early with an actionable, OS-aware install hint so users on
+# minimal images (containers, fresh VPS, etc.) aren't stuck staring at a cryptic
+# `command not found` halfway through the install.
+#
+# On macOS we require `ditto` (Apple's archive tool, part of the base install)
+# so notarized/code-signed .app bundles are reconstructed exactly. Info-ZIP
+# `unzip` mangles symlinks/permissions/xattrs and breaks the signature seal,
+# which on Apple Silicon yields "is damaged and cannot be opened." On Linux we
+# require `unzip`.
+require_extractor() {
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    if command -v ditto > /dev/null 2>&1; then
+      return 0
+    fi
+    log_error "'ditto' is required to install Junie on macOS, but it was not found in PATH."
+    log_error "'ditto' ships with macOS at /usr/bin/ditto; ensure /usr/bin is on your PATH and re-run this installer."
+    exit 1
+  fi
   if command -v unzip > /dev/null 2>&1; then
     return 0
   fi
   log_error "'unzip' is required to install Junie, but it was not found in PATH."
-  if [[ "$(uname -s)" == "Darwin" ]]; then
-    log_error "Install it with: brew install unzip"
-  elif command -v apt-get > /dev/null 2>&1; then
+  if command -v apt-get > /dev/null 2>&1; then
     log_error "Install it with: sudo apt-get update && sudo apt-get install -y unzip"
   elif command -v dnf > /dev/null 2>&1; then
     log_error "Install it with: sudo dnf install -y unzip"
@@ -47,7 +59,7 @@ require_unzip() {
   fi
   exit 1
 }
-require_unzip
+require_extractor
 
 # Calculate SHA-256 checksum
 sha256sum_file() {
@@ -266,18 +278,32 @@ get_binary_path() {
   get_binary_path_in "$VERSIONS_DIR/$version"
 }
 
+# Pick the zip extractor for the current OS. On macOS we must use `ditto`
+# (Apple's archive tool) so notarized/code-signed .app bundles are
+# reconstructed exactly -- symlinks, permissions, and extended attributes
+# intact. Info-ZIP `unzip` mangles those and breaks the signature seal, which
+# on Apple Silicon yields "is damaged and cannot be opened." On Linux we keep
+# `unzip`.
+zip_extractor() {
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    echo "ditto"
+  else
+    echo "unzip"
+  fi
+}
+
 # Detect the archive type of $1 by extension or magic bytes.
-# Echoes "unzip", "tar", or "" if unknown.
+# Echoes the zip extractor ("unzip" or "ditto"), "tar", or "" if unknown.
 detect_archive_type() {
   local file="$1"
   case "$file" in
-    *.zip|*.ZIP) echo "unzip"; return 0 ;;
+    *.zip|*.ZIP) zip_extractor; return 0 ;;
     *.tar.gz|*.tgz|*.TAR.GZ|*.TGZ) echo "tar"; return 0 ;;
   esac
   local magic
   magic=$(head -c 4 "$file" 2>/dev/null | od -An -tx1 | tr -d ' \n' 2>/dev/null || echo "")
   case "$magic" in
-    504b0304*|504b0506*|504b0708*) echo "unzip" ;;
+    504b0304*|504b0506*|504b0708*) zip_extractor ;;
     1f8b*)                          echo "tar"   ;;
     *)                              echo ""      ;;
   esac
@@ -427,6 +453,17 @@ apply_pending_update() {
     if ! unzip -q "$zip_path" -d "$staging"; then
       log_both "Error: Failed to extract $zip_path; preserving update for retry"
       log_upgrade "extract: FAIL (unzip exit non-zero)"
+      rm -rf "$staging"
+      trap - INT TERM
+      return 1
+    fi
+  elif [[ "$extractor" == "ditto" ]]; then
+    # macOS: use ditto so the signed .app bundle is reconstructed exactly.
+    # No unzip fallback -- on failure we preserve the update for retry to
+    # avoid installing a structurally broken (and thus "damaged") bundle.
+    if ! ditto -x -k "$zip_path" "$staging"; then
+      log_both "Error: Failed to extract $zip_path; preserving update for retry"
+      log_upgrade "extract: FAIL (ditto exit non-zero)"
       rm -rf "$staging"
       trap - INT TERM
       return 1
@@ -689,7 +726,13 @@ STAGING="$JUNIE_DATA/versions/.$VERSION.tmp.$$"
 trap 'rm -rf "$STAGING"' EXIT INT TERM
 rm -rf "$STAGING"
 mkdir -p "$STAGING"
-unzip -q "$TMP_ZIP" -d "$STAGING"
+# On macOS use ditto so the signed .app bundle is reconstructed exactly;
+# on Linux use unzip. (See require_extractor above for the rationale.)
+if [[ "$OS_NAME" == "macos" ]]; then
+  ditto -x -k "$TMP_ZIP" "$STAGING"
+else
+  unzip -q "$TMP_ZIP" -d "$STAGING"
+fi
 rm -f "$TMP_ZIP"
 
 # Validate the extracted binary (inline equivalent of get_binary_path_in).

--- a/install-experimental.sh
+++ b/install-experimental.sh
@@ -19,18 +19,30 @@ JUNIE_DATA="$HOME/.local/share/junie"
 log() { echo "[Junie] $*"; }
 log_error() { echo "[Junie] ERROR: $*" >&2; }
 
-# Ensure required tools are available before we start downloading anything.
-# We fail early with an actionable, OS-aware install hint so users on minimal
-# images (containers, fresh VPS, etc.) aren't stuck staring at a cryptic
-# `unzip: command not found` halfway through the install.
-require_unzip() {
+# Ensure the required archive extractor is available before we start downloading
+# anything. We fail early with an actionable, OS-aware install hint so users on
+# minimal images (containers, fresh VPS, etc.) aren't stuck staring at a cryptic
+# `command not found` halfway through the install.
+#
+# On macOS we require `ditto` (Apple's archive tool, part of the base install)
+# so notarized/code-signed .app bundles are reconstructed exactly. Info-ZIP
+# `unzip` mangles symlinks/permissions/xattrs and breaks the signature seal,
+# which on Apple Silicon yields "is damaged and cannot be opened." On Linux we
+# require `unzip`.
+require_extractor() {
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    if command -v ditto > /dev/null 2>&1; then
+      return 0
+    fi
+    log_error "'ditto' is required to install Junie on macOS, but it was not found in PATH."
+    log_error "'ditto' ships with macOS at /usr/bin/ditto; ensure /usr/bin is on your PATH and re-run this installer."
+    exit 1
+  fi
   if command -v unzip > /dev/null 2>&1; then
     return 0
   fi
   log_error "'unzip' is required to install Junie, but it was not found in PATH."
-  if [[ "$(uname -s)" == "Darwin" ]]; then
-    log_error "Install it with: brew install unzip"
-  elif command -v apt-get > /dev/null 2>&1; then
+  if command -v apt-get > /dev/null 2>&1; then
     log_error "Install it with: sudo apt-get update && sudo apt-get install -y unzip"
   elif command -v dnf > /dev/null 2>&1; then
     log_error "Install it with: sudo dnf install -y unzip"
@@ -47,7 +59,7 @@ require_unzip() {
   fi
   exit 1
 }
-require_unzip
+require_extractor
 
 # Calculate SHA-256 checksum
 sha256sum_file() {
@@ -266,18 +278,32 @@ get_binary_path() {
   get_binary_path_in "$VERSIONS_DIR/$version"
 }
 
+# Pick the zip extractor for the current OS. On macOS we must use `ditto`
+# (Apple's archive tool) so notarized/code-signed .app bundles are
+# reconstructed exactly -- symlinks, permissions, and extended attributes
+# intact. Info-ZIP `unzip` mangles those and breaks the signature seal, which
+# on Apple Silicon yields "is damaged and cannot be opened." On Linux we keep
+# `unzip`.
+zip_extractor() {
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    echo "ditto"
+  else
+    echo "unzip"
+  fi
+}
+
 # Detect the archive type of $1 by extension or magic bytes.
-# Echoes "unzip", "tar", or "" if unknown.
+# Echoes the zip extractor ("unzip" or "ditto"), "tar", or "" if unknown.
 detect_archive_type() {
   local file="$1"
   case "$file" in
-    *.zip|*.ZIP) echo "unzip"; return 0 ;;
+    *.zip|*.ZIP) zip_extractor; return 0 ;;
     *.tar.gz|*.tgz|*.TAR.GZ|*.TGZ) echo "tar"; return 0 ;;
   esac
   local magic
   magic=$(head -c 4 "$file" 2>/dev/null | od -An -tx1 | tr -d ' \n' 2>/dev/null || echo "")
   case "$magic" in
-    504b0304*|504b0506*|504b0708*) echo "unzip" ;;
+    504b0304*|504b0506*|504b0708*) zip_extractor ;;
     1f8b*)                          echo "tar"   ;;
     *)                              echo ""      ;;
   esac
@@ -427,6 +453,17 @@ apply_pending_update() {
     if ! unzip -q "$zip_path" -d "$staging"; then
       log_both "Error: Failed to extract $zip_path; preserving update for retry"
       log_upgrade "extract: FAIL (unzip exit non-zero)"
+      rm -rf "$staging"
+      trap - INT TERM
+      return 1
+    fi
+  elif [[ "$extractor" == "ditto" ]]; then
+    # macOS: use ditto so the signed .app bundle is reconstructed exactly.
+    # No unzip fallback -- on failure we preserve the update for retry to
+    # avoid installing a structurally broken (and thus "damaged") bundle.
+    if ! ditto -x -k "$zip_path" "$staging"; then
+      log_both "Error: Failed to extract $zip_path; preserving update for retry"
+      log_upgrade "extract: FAIL (ditto exit non-zero)"
       rm -rf "$staging"
       trap - INT TERM
       return 1
@@ -689,7 +726,13 @@ STAGING="$JUNIE_DATA/versions/.$VERSION.tmp.$$"
 trap 'rm -rf "$STAGING"' EXIT INT TERM
 rm -rf "$STAGING"
 mkdir -p "$STAGING"
-unzip -q "$TMP_ZIP" -d "$STAGING"
+# On macOS use ditto so the signed .app bundle is reconstructed exactly;
+# on Linux use unzip. (See require_extractor above for the rationale.)
+if [[ "$OS_NAME" == "macos" ]]; then
+  ditto -x -k "$TMP_ZIP" "$STAGING"
+else
+  unzip -q "$TMP_ZIP" -d "$STAGING"
+fi
 rm -f "$TMP_ZIP"
 
 # Validate the extracted binary (inline equivalent of get_binary_path_in).

--- a/install-nightly.sh
+++ b/install-nightly.sh
@@ -19,18 +19,30 @@ JUNIE_DATA="$HOME/.local/share/junie"
 log() { echo "[Junie] $*"; }
 log_error() { echo "[Junie] ERROR: $*" >&2; }
 
-# Ensure required tools are available before we start downloading anything.
-# We fail early with an actionable, OS-aware install hint so users on minimal
-# images (containers, fresh VPS, etc.) aren't stuck staring at a cryptic
-# `unzip: command not found` halfway through the install.
-require_unzip() {
+# Ensure the required archive extractor is available before we start downloading
+# anything. We fail early with an actionable, OS-aware install hint so users on
+# minimal images (containers, fresh VPS, etc.) aren't stuck staring at a cryptic
+# `command not found` halfway through the install.
+#
+# On macOS we require `ditto` (Apple's archive tool, part of the base install)
+# so notarized/code-signed .app bundles are reconstructed exactly. Info-ZIP
+# `unzip` mangles symlinks/permissions/xattrs and breaks the signature seal,
+# which on Apple Silicon yields "is damaged and cannot be opened." On Linux we
+# require `unzip`.
+require_extractor() {
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    if command -v ditto > /dev/null 2>&1; then
+      return 0
+    fi
+    log_error "'ditto' is required to install Junie on macOS, but it was not found in PATH."
+    log_error "'ditto' ships with macOS at /usr/bin/ditto; ensure /usr/bin is on your PATH and re-run this installer."
+    exit 1
+  fi
   if command -v unzip > /dev/null 2>&1; then
     return 0
   fi
   log_error "'unzip' is required to install Junie, but it was not found in PATH."
-  if [[ "$(uname -s)" == "Darwin" ]]; then
-    log_error "Install it with: brew install unzip"
-  elif command -v apt-get > /dev/null 2>&1; then
+  if command -v apt-get > /dev/null 2>&1; then
     log_error "Install it with: sudo apt-get update && sudo apt-get install -y unzip"
   elif command -v dnf > /dev/null 2>&1; then
     log_error "Install it with: sudo dnf install -y unzip"
@@ -47,7 +59,7 @@ require_unzip() {
   fi
   exit 1
 }
-require_unzip
+require_extractor
 
 # Calculate SHA-256 checksum
 sha256sum_file() {
@@ -266,18 +278,32 @@ get_binary_path() {
   get_binary_path_in "$VERSIONS_DIR/$version"
 }
 
+# Pick the zip extractor for the current OS. On macOS we must use `ditto`
+# (Apple's archive tool) so notarized/code-signed .app bundles are
+# reconstructed exactly -- symlinks, permissions, and extended attributes
+# intact. Info-ZIP `unzip` mangles those and breaks the signature seal, which
+# on Apple Silicon yields "is damaged and cannot be opened." On Linux we keep
+# `unzip`.
+zip_extractor() {
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    echo "ditto"
+  else
+    echo "unzip"
+  fi
+}
+
 # Detect the archive type of $1 by extension or magic bytes.
-# Echoes "unzip", "tar", or "" if unknown.
+# Echoes the zip extractor ("unzip" or "ditto"), "tar", or "" if unknown.
 detect_archive_type() {
   local file="$1"
   case "$file" in
-    *.zip|*.ZIP) echo "unzip"; return 0 ;;
+    *.zip|*.ZIP) zip_extractor; return 0 ;;
     *.tar.gz|*.tgz|*.TAR.GZ|*.TGZ) echo "tar"; return 0 ;;
   esac
   local magic
   magic=$(head -c 4 "$file" 2>/dev/null | od -An -tx1 | tr -d ' \n' 2>/dev/null || echo "")
   case "$magic" in
-    504b0304*|504b0506*|504b0708*) echo "unzip" ;;
+    504b0304*|504b0506*|504b0708*) zip_extractor ;;
     1f8b*)                          echo "tar"   ;;
     *)                              echo ""      ;;
   esac
@@ -427,6 +453,17 @@ apply_pending_update() {
     if ! unzip -q "$zip_path" -d "$staging"; then
       log_both "Error: Failed to extract $zip_path; preserving update for retry"
       log_upgrade "extract: FAIL (unzip exit non-zero)"
+      rm -rf "$staging"
+      trap - INT TERM
+      return 1
+    fi
+  elif [[ "$extractor" == "ditto" ]]; then
+    # macOS: use ditto so the signed .app bundle is reconstructed exactly.
+    # No unzip fallback -- on failure we preserve the update for retry to
+    # avoid installing a structurally broken (and thus "damaged") bundle.
+    if ! ditto -x -k "$zip_path" "$staging"; then
+      log_both "Error: Failed to extract $zip_path; preserving update for retry"
+      log_upgrade "extract: FAIL (ditto exit non-zero)"
       rm -rf "$staging"
       trap - INT TERM
       return 1
@@ -689,7 +726,13 @@ STAGING="$JUNIE_DATA/versions/.$VERSION.tmp.$$"
 trap 'rm -rf "$STAGING"' EXIT INT TERM
 rm -rf "$STAGING"
 mkdir -p "$STAGING"
-unzip -q "$TMP_ZIP" -d "$STAGING"
+# On macOS use ditto so the signed .app bundle is reconstructed exactly;
+# on Linux use unzip. (See require_extractor above for the rationale.)
+if [[ "$OS_NAME" == "macos" ]]; then
+  ditto -x -k "$TMP_ZIP" "$STAGING"
+else
+  unzip -q "$TMP_ZIP" -d "$STAGING"
+fi
 rm -f "$TMP_ZIP"
 
 # Validate the extracted binary (inline equivalent of get_binary_path_in).

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,5 @@
 #
+# DO NOT EDIT — generated from templates/install.ps1.template by templates/generate.sh
 # Junie CLI Installer for Windows
 # Usage: irm https://junie.jetbrains.com/install.ps1 | iex
 #
@@ -25,7 +26,7 @@ function Get-Sha256($file) {
 $ARCH = $env:PROCESSOR_ARCHITECTURE
 switch ($ARCH) {
   "AMD64"   {$ARCH_NAME = "amd64" }
-  "ARM64"   {$ARCH_NAME = "amd64" }
+  "ARM64"   {$ARCH_NAME = "aarch64" }
   default   { Log-Error "Unsupported architecture: $ARCH"; exit 1 }
 }
 
@@ -54,12 +55,46 @@ function Fetch-LatestVersion {
   }
 }
 
+# Look up the SHA-256 checksum for a specific version+platform from the
+# update-info JSONL so that explicit JUNIE_VERSION requests can still be
+# integrity-checked. Returns the checksum if found, or an empty string otherwise.
+# Best-effort: network/parse failures or a version that isn't listed simply
+# result in an empty checksum (the caller decides how to proceed).
+function Fetch-VersionSha256($wantVersion) {
+  try {
+    $jsonl = Invoke-RestMethod -Uri $UPDATE_INFO_URL
+  } catch {
+    return ""
+  }
+
+  $lines = $jsonl -split "`n" | Where-Object { $_ -match "`"platform`":`"$PLATFORM`"" }
+  foreach ($line in $lines) {
+    try {
+      $parsed = $line | ConvertFrom-Json
+    } catch {
+      continue
+    }
+    if ($parsed.version -eq $wantVersion) {
+      return $parsed.sha256
+    }
+  }
+  return ""
+}
+
 # Determine version: use JUNIE_VERSION env var if set, otherwise fetch latest
 if ($env:JUNIE_VERSION) {
   $VERSION = $env:JUNIE_VERSION
   $DOWNLOAD_URL = "$GITHUB_RELEASES/download/$VERSION/junie-$CHANNEL-$VERSION-$PLATFORM.zip"
-  $SHA256 = ""
   Log "Using specified version: $VERSION"
+  # Even for an explicitly requested version, try to look up its published
+  # checksum so the download is still integrity-checked. If the version isn't
+  # listed in update-info we proceed without a checksum (best-effort).
+  $SHA256 = Fetch-VersionSha256 $VERSION
+  if ($SHA256) {
+    Log "Found published checksum for version $VERSION"
+  } else {
+    Log "Warning: No checksum found for version $VERSION; proceeding without integrity verification"
+  }
 } else {
   Fetch-LatestVersion
 }
@@ -72,38 +107,60 @@ New-Item -ItemType Directory -Force -Path "$JUNIE_DATA\versions" | Out-Null
 New-Item -ItemType Directory -Force -Path "$JUNIE_DATA\updates" | Out-Null
 
 # Download and install binary
+# Always re-download and overwrite the target version directory, regardless of
+# whether it already exists. This avoids reusing a previously cached broken or
+# partial install for the same version.
 $TARGET_DIR = Join-Path "$JUNIE_DATA\versions" $VERSION
 
-if (-not (Test-Path $TARGET_DIR)) {
-  $TMP_ZIP = Join-Path $env:TEMP "junie-$VERSION.zip"
+$TMP_ZIP = Join-Path $env:TEMP "junie-$VERSION.zip"
 
-  Log "Downloading $DOWNLOAD_URL"
-  $oldProgress = $ProgressPreference
-  $ProgressPreference = 'SilentlyContinue'
-  Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile $TMP_ZIP -UseBasicParsing
-  $ProgressPreference = $oldProgress
+Log "Downloading $DOWNLOAD_URL"
+$oldProgress = $ProgressPreference
+$ProgressPreference = 'SilentlyContinue'
+Invoke-WebRequest -Uri $DOWNLOAD_URL -OutFile $TMP_ZIP -UseBasicParsing
+$ProgressPreference = $oldProgress
 
-  # Verify checksum
-  if ($SHA256) {
-    $actualSha256 = Get-Sha256 $TMP_ZIP
-    if ($actualSha256 -ne $SHA256.ToLower()) {
-      Log-Error "Checksum verification failed!"
-      Log-Error "Expected: $SHA256"
-      Log-Error "Got: $actualSha256"
-      Remove-Item -Force $TMP_ZIP
-      exit 1
-    }
-    Log "Checksum verified"
+# Verify checksum
+if ($SHA256) {
+  $actualSha256 = Get-Sha256 $TMP_ZIP
+  if ($actualSha256 -ne $SHA256.ToLower()) {
+    Log-Error "Checksum verification failed!"
+    Log-Error "Expected: $SHA256"
+    Log-Error "Got: $actualSha256"
+    Remove-Item -Force $TMP_ZIP
+    exit 1
   }
+  Log "Checksum verified"
+}
 
-  New-Item -ItemType Directory -Force -Path $TARGET_DIR | Out-Null
+# Extract to a staging dir on the same filesystem as $TARGET_DIR, validate the
+# resolved binary, then atomically rename into place. This mirrors the shim's
+# robust extraction so an interrupted install never leaves a half-extracted tree.
+$STAGING = Join-Path "$JUNIE_DATA\versions" (".$VERSION.tmp." + $PID)
+if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
+New-Item -ItemType Directory -Force -Path $STAGING | Out-Null
 
+try {
   $oldProgress = $global:ProgressPreference
   $global:ProgressPreference = 'SilentlyContinue'
-  Expand-Archive -Path $TMP_ZIP -DestinationPath $TARGET_DIR -Force
+  Expand-Archive -Path $TMP_ZIP -DestinationPath $STAGING -Force
   $global:ProgressPreference = $oldProgress
 
-  Remove-Item -Force $TMP_ZIP
+  # Validate that the expected binary is present in the staging tree.
+  $StagedExe = Join-Path $STAGING "junie\junie.exe"
+  if (-not (Test-Path $StagedExe)) {
+    Log-Error "No junie binary found in downloaded payload"
+    exit 1
+  }
+
+  # Remove any existing (possibly broken) version directory before the rename.
+  if (Test-Path $TARGET_DIR) { Remove-Item -Recurse -Force $TARGET_DIR }
+  Move-Item -Path $STAGING -Destination $TARGET_DIR
+} catch {
+  if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
+  throw
+} finally {
+  Remove-Item -Force $TMP_ZIP -ErrorAction SilentlyContinue
 }
 
 # Write current version pointer file (plain text, not symlink)
@@ -134,6 +191,33 @@ set "VERSIONS_DIR=%JUNIE_DATA%\versions"
 set "UPDATES_DIR=%JUNIE_DATA%\updates"
 set "CURRENT_FILE=%JUNIE_DATA%\current"
 set "PENDING_UPDATE=%UPDATES_DIR%\pending-update.json"
+set "PROCESSING=%UPDATES_DIR%\pending-update.json.processing"
+
+::: === Defensive Sanitization ===
+:::
+::: JUNIE-2957 defense: drop pending-update.json / pending-update.json.processing
+::: if they are empty or unparseable BEFORE the atomic-claim rename below. A
+::: legitimate in-flight update writes the manifest fully and then renames it,
+::: so a zero-byte file or one missing `version`/`zipPath` can only be junk --
+::: a leftover from a prior crash or content planted by mistake. Without this,
+::: a stale .processing blocks all future updates AND can be inherited by the
+::: binary's own update path with CWD as a working-dir hint.
+if exist "%PENDING_UPDATE%" (
+  set "PEND_OK="
+  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '%PENDING_UPDATE%' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c ^| ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PEND_OK=%%V"
+  if /i not "!PEND_OK!"=="ok" (
+    echo [Junie] Removing invalid update artifact: %PENDING_UPDATE% 1>&2
+    del /f /q "%PENDING_UPDATE%" 2>nul
+  )
+)
+if exist "!PROCESSING!" (
+  set "PROC_OK="
+  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '!PROCESSING!' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c ^| ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PROC_OK=%%V"
+  if /i not "!PROC_OK!"=="ok" (
+    echo [Junie] Removing invalid update artifact: !PROCESSING! 1>&2
+    del /f /q "!PROCESSING!" 2>nul
+  )
+)
 
 :: === Apply Pending Update ===
 if not exist "%PENDING_UPDATE%" goto :resolve_version
@@ -181,22 +265,54 @@ if defined UPD_SHA256 (
   )
 )
 
-:: Extract to versions directory
+:: Extract to a staging dir on the same filesystem as %VERSIONS_DIR%, validate
+:: the resolved binary, then atomically rename into place. On any failure we
+:: rename the claimed manifest back to pending-update.json so the next launch
+:: retries (keeping the zip), and continue with the previously installed version.
 set "UPD_TARGET=%VERSIONS_DIR%\!UPD_VERSION!"
-if not exist "!UPD_TARGET!" mkdir "!UPD_TARGET!"
+set "UPD_RND=!RANDOM!"
+set "UPD_STAGING_NAME=.!UPD_VERSION!.tmp.!UPD_RND!"
+set "UPD_OLD_NAME=.!UPD_VERSION!.old.!UPD_RND!"
+set "UPD_STAGING=%VERSIONS_DIR%\!UPD_STAGING_NAME!"
+set "UPD_OLD=%VERSIONS_DIR%\!UPD_OLD_NAME!"
+if exist "!UPD_STAGING!" rmdir /s /q "!UPD_STAGING!" 2>nul
+mkdir "!UPD_STAGING!" 2>nul
 
 echo [Junie] Applying pending update to version !UPD_VERSION!... 1>&2
-powershell -NoProfile -Command "Expand-Archive -Path '!UPD_ZIP!' -DestinationPath '!UPD_TARGET!' -Force" 2>nul
+powershell -NoProfile -Command "Expand-Archive -Path '!UPD_ZIP!' -DestinationPath '!UPD_STAGING!' -Force" 2>nul
 if errorlevel 1 (
-  echo [Junie] Failed to extract update 1>&2
-  del /f /q "!CLAIMED_UPDATE!" 2>nul
+  echo [Junie] Failed to extract update; preserving for retry 1>&2
+  rmdir /s /q "!UPD_STAGING!" 2>nul
+  rename "!CLAIMED_UPDATE!" "pending-update.json" 2>nul
   goto :resolve_version
 )
 
-:: Update current pointer file (plain text, not symlink)
+:: Validate extracted binary
+if not exist "!UPD_STAGING!\junie\junie.exe" (
+  echo [Junie] Extracted payload missing junie\junie.exe; preserving for retry 1>&2
+  rmdir /s /q "!UPD_STAGING!" 2>nul
+  rename "!CLAIMED_UPDATE!" "pending-update.json" 2>nul
+  goto :resolve_version
+)
+
+:: Atomic swap: move any existing version aside, then rename staging into place.
+if exist "!UPD_TARGET!" rename "!UPD_TARGET!" "!UPD_OLD_NAME!" 2>nul
+move "!UPD_STAGING!" "!UPD_TARGET!" >nul 2>nul
+if errorlevel 1 (
+  echo [Junie] Failed to install new version; preserving for retry 1>&2
+  if exist "!UPD_OLD!" if not exist "!UPD_TARGET!" rename "!UPD_OLD!" "!UPD_VERSION!" 2>nul
+  rmdir /s /q "!UPD_STAGING!" 2>nul
+  rename "!CLAIMED_UPDATE!" "pending-update.json" 2>nul
+  goto :resolve_version
+)
+
+:: Best-effort cleanup of the previous tree
+if exist "!UPD_OLD!" rmdir /s /q "!UPD_OLD!" 2>nul
+
+:: Update current pointer file (plain text, not symlink) after a successful swap.
 >"%CURRENT_FILE%" (echo|set /p="!UPD_VERSION!")
 
-:: Cleanup downloaded zip and manifest
+:: Cleanup downloaded zip and manifest only after a successful swap
 del /f /q "!UPD_ZIP!" 2>nul
 del /f /q "!CLAIMED_UPDATE!" 2>nul
 echo [Junie] Updated to version !UPD_VERSION! 1>&2

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# DO NOT EDIT — generated from templates/install.sh.template by templates/generate.sh
 #
 # Junie CLI Installer
 # Usage: curl -fsSL https://junie.jetbrains.com/install.sh | bash
@@ -17,6 +18,48 @@ JUNIE_DATA="$HOME/.local/share/junie"
 
 log() { echo "[Junie] $*"; }
 log_error() { echo "[Junie] ERROR: $*" >&2; }
+
+# Ensure the required archive extractor is available before we start downloading
+# anything. We fail early with an actionable, OS-aware install hint so users on
+# minimal images (containers, fresh VPS, etc.) aren't stuck staring at a cryptic
+# `command not found` halfway through the install.
+#
+# On macOS we require `ditto` (Apple's archive tool, part of the base install)
+# so notarized/code-signed .app bundles are reconstructed exactly. Info-ZIP
+# `unzip` mangles symlinks/permissions/xattrs and breaks the signature seal,
+# which on Apple Silicon yields "is damaged and cannot be opened." On Linux we
+# require `unzip`.
+require_extractor() {
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    if command -v ditto > /dev/null 2>&1; then
+      return 0
+    fi
+    log_error "'ditto' is required to install Junie on macOS, but it was not found in PATH."
+    log_error "'ditto' ships with macOS at /usr/bin/ditto; ensure /usr/bin is on your PATH and re-run this installer."
+    exit 1
+  fi
+  if command -v unzip > /dev/null 2>&1; then
+    return 0
+  fi
+  log_error "'unzip' is required to install Junie, but it was not found in PATH."
+  if command -v apt-get > /dev/null 2>&1; then
+    log_error "Install it with: sudo apt-get update && sudo apt-get install -y unzip"
+  elif command -v dnf > /dev/null 2>&1; then
+    log_error "Install it with: sudo dnf install -y unzip"
+  elif command -v yum > /dev/null 2>&1; then
+    log_error "Install it with: sudo yum install -y unzip"
+  elif command -v apk > /dev/null 2>&1; then
+    log_error "Install it with: sudo apk add unzip"
+  elif command -v pacman > /dev/null 2>&1; then
+    log_error "Install it with: sudo pacman -S --noconfirm unzip"
+  elif command -v zypper > /dev/null 2>&1; then
+    log_error "Install it with: sudo zypper install -y unzip"
+  else
+    log_error "Install the 'unzip' package using your system package manager, then re-run this installer."
+  fi
+  exit 1
+}
+require_extractor
 
 # Calculate SHA-256 checksum
 sha256sum_file() {
@@ -57,6 +100,24 @@ fetch_latest_version() {
   fi
 }
 
+# Look up the SHA-256 checksum for a specific version+platform from the
+# update-info JSONL so that explicit JUNIE_VERSION requests can still be
+# integrity-checked. Echoes the checksum if found, or an empty string otherwise.
+# Best-effort: network/parse failures or a version that isn't listed simply
+# result in an empty checksum (the caller decides how to proceed).
+fetch_version_sha256() {
+  local want_version="$1"
+  local jsonl entry
+  jsonl=$(curl -fsSL "$UPDATE_INFO_URL" 2> /dev/null) || return 0
+
+  # Match the entry for the exact version (trailing quote anchors the match so
+  # "1.1" does not match "1.12") and our platform.
+  entry=$(echo "$jsonl" | grep "\"version\":\"$want_version\"" | grep "\"platform\":\"$PLATFORM\"" | tail -1)
+  [[ -z "$entry" ]] && return 0
+
+  echo "$entry" | grep -o '"sha256":"[^"]*"' | sed 's/"sha256":"\([^"]*\)"/\1/'
+}
+
 # Detect platform
 OS=$(uname -s)
 ARCH=$(uname -m)
@@ -79,8 +140,16 @@ PLATFORM="${OS_NAME}-${ARCH_NAME}"
 if [[ -n "${JUNIE_VERSION:-}" ]]; then
   VERSION="$JUNIE_VERSION"
   DOWNLOAD_URL="$GITHUB_RELEASES/download/${VERSION}/junie-${CHANNEL}-${VERSION}-${PLATFORM}.zip"
-  SHA256=""  # No checksum verification for specific version requests
   log "Using specified version: $VERSION"
+  # Even for an explicitly requested version, try to look up its published
+  # checksum so the download is still integrity-checked. If the version isn't
+  # listed in update-info we proceed without a checksum (best-effort).
+  SHA256=$(fetch_version_sha256 "$VERSION")
+  if [[ -n "$SHA256" ]]; then
+    log "Found published checksum for version $VERSION"
+  else
+    log "Warning: No checksum found for version $VERSION; proceeding without integrity verification"
+  fi
 else
   fetch_latest_version
 fi
@@ -118,11 +187,32 @@ UPDATES_DIR="$JUNIE_DATA/updates"
 CURRENT_LINK="$JUNIE_DATA/current"
 PENDING_UPDATE="$UPDATES_DIR/pending-update.json"
 
+# Persistent upgrade log. Lives under ~/.junie/logs (separate from the data dir,
+# so wiping ~/.local/share/junie during reinstall does not lose update history).
+# Always APPEND -- never truncate.
+UPGRADE_LOG_DIR="${JUNIE_LOG_DIR:-$HOME/.junie/logs}"
+UPGRADE_LOG="$UPGRADE_LOG_DIR/upgrade.log"
+
 # === Utility Functions ===
 
 # Log message to stderr
 log() {
   echo "[Junie] $*" >&2
+}
+
+# Append a timestamped line to the upgrade log. Best-effort: failure to write
+# (e.g. read-only HOME) must never break the update flow itself, so all errors
+# are swallowed. Always opens the file in append mode (>>).
+log_upgrade() {
+  local ts
+  ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "-")
+  { mkdir -p "$UPGRADE_LOG_DIR" 2>/dev/null && printf '%s [pid=%s] %s\n' "$ts" "$$" "$*" >> "$UPGRADE_LOG"; } 2>/dev/null || true
+}
+
+# Convenience: echo to stderr AND append to upgrade.log.
+log_both() {
+  log "$*"
+  log_upgrade "$*"
 }
 
 # Check if a command exists
@@ -163,11 +253,10 @@ sha256sum_file() {
   fi
 }
 
-# Get binary path for a given version
-# Handles different package structures (macOS app bundle, Linux, direct binary)
-get_binary_path() {
-  local version="$1"
-  local version_dir="$VERSIONS_DIR/$version"
+# Get binary path for an arbitrary version directory.
+# Handles different package structures (macOS app bundle, Linux, direct binary).
+get_binary_path_in() {
+  local version_dir="$1"
 
   # macOS: look for .app bundle
   if [[ -d "$version_dir/Applications/junie.app" ]]; then
@@ -183,76 +272,279 @@ get_binary_path() {
   fi
 }
 
+# Get binary path for a given version (by name).
+get_binary_path() {
+  local version="$1"
+  get_binary_path_in "$VERSIONS_DIR/$version"
+}
+
+# Pick the zip extractor for the current OS. On macOS we must use `ditto`
+# (Apple's archive tool) so notarized/code-signed .app bundles are
+# reconstructed exactly -- symlinks, permissions, and extended attributes
+# intact. Info-ZIP `unzip` mangles those and breaks the signature seal, which
+# on Apple Silicon yields "is damaged and cannot be opened." On Linux we keep
+# `unzip`.
+zip_extractor() {
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    echo "ditto"
+  else
+    echo "unzip"
+  fi
+}
+
+# Detect the archive type of $1 by extension or magic bytes.
+# Echoes the zip extractor ("unzip" or "ditto"), "tar", or "" if unknown.
+detect_archive_type() {
+  local file="$1"
+  case "$file" in
+    *.zip|*.ZIP) zip_extractor; return 0 ;;
+    *.tar.gz|*.tgz|*.TAR.GZ|*.TGZ) echo "tar"; return 0 ;;
+  esac
+  local magic
+  magic=$(head -c 4 "$file" 2>/dev/null | od -An -tx1 | tr -d ' \n' 2>/dev/null || echo "")
+  case "$magic" in
+    504b0304*|504b0506*|504b0708*) zip_extractor ;;
+    1f8b*)                          echo "tar"   ;;
+    *)                              echo ""      ;;
+  esac
+}
+
+# === Defensive Sanitization ===
+#
+# JUNIE-2957 defense: drop update artifacts that are empty or unparseable
+# BEFORE we (or the binary's own update path) act on them.
+#
+# A legitimate in-flight update writes the manifest fully and only then renames
+# it into place, so an existing `pending-update.json` or
+# `pending-update.json.processing` that is zero bytes, or that lacks the
+# required `version` / `zipPath` fields, can only be junk -- a leftover from a
+# prior crash, a partial write, or content planted by mistake. We must not feed
+# that to either `apply_pending_update` below or to the launched binary, which
+# may otherwise try to "resolve" paths derived from CWD/EJ_RUNNER_PWD.
+#
+# Best-effort: any rm failure is swallowed; the regular `apply_pending_update`
+# path will then handle the file conservatively or skip it.
+sanitize_pending_updates() {
+  [[ -d "$UPDATES_DIR" ]] || return 0
+  local f v z
+  for f in "$PENDING_UPDATE" "$UPDATES_DIR/pending-update.json.processing"; do
+    [[ -f "$f" ]] || continue
+    if [[ ! -s "$f" ]]; then
+      log_both "Removing zero-byte update artifact: $f"
+      rm -f "$f" 2>/dev/null || true
+      continue
+    fi
+    v=$(get_json_field "$f" "version")
+    z=$(get_json_field "$f" "zipPath")
+    if [[ -z "$v" || -z "$z" ]]; then
+      log_both "Removing unparseable update artifact (missing version/zipPath): $f"
+      rm -f "$f" 2>/dev/null || true
+    fi
+  done
+}
+
 # === Apply Pending Update ===
+#
+# Atomic extraction strategy:
+#   1. Verify manifest and checksum.
+#   2. Extract into a staging directory inside $VERSIONS_DIR (same FS, so `mv` is a rename).
+#   3. Validate the resolved binary in the staging tree is executable.
+#   4. Swap the staging dir into $VERSIONS_DIR/$version (replacing any previous tree
+#      wholesale -- important for macOS .app code-signing consistency).
+#   5. Flip the `current` symlink.
+#   6. Only then delete the zip + pending manifest.
+#
+# Failure modes:
+#   - Poisoned manifest (missing fields, missing zip, checksum mismatch):
+#       drop manifest + zip, return non-zero.
+#   - Retryable failure (extraction error, validation failure, missing extractor):
+#       preserve manifest + zip so the next launch retries, return non-zero.
+# In all failure cases $VERSIONS_DIR/$version is left untouched from before the attempt.
 apply_pending_update() {
   if [[ ! -f "$PENDING_UPDATE" ]]; then
     return 0
   fi
 
-  log "Applying pending update..."
+  log_both "Applying pending update (manifest=$PENDING_UPDATE)"
 
   # Parse manifest
   local version zip_path sha256
   version=$(get_json_field "$PENDING_UPDATE" "version")
   zip_path=$(get_json_field "$PENDING_UPDATE" "zipPath")
   sha256=$(get_json_field "$PENDING_UPDATE" "sha256")
+  log_upgrade "manifest parsed: version='$version' zipPath='$zip_path' sha256='${sha256:-<none>}'"
 
   if [[ -z "$version" || -z "$zip_path" ]]; then
-    log "Invalid pending update manifest, skipping"
+    log_both "Invalid pending update manifest, skipping"
     rm -f "$PENDING_UPDATE"
     return 1
   fi
 
   if [[ ! -f "$zip_path" ]]; then
-    log "Update file not found: $zip_path"
+    log_both "Update file not found: $zip_path"
     rm -f "$PENDING_UPDATE"
     return 1
   fi
 
+  local zip_size=""
+  zip_size=$(wc -c < "$zip_path" 2>/dev/null | tr -d ' ' || echo "?")
+  log_upgrade "archive present: path='$zip_path' size_bytes=$zip_size"
+
   # Verify checksum if available
   if [[ -n "$sha256" ]]; then
+    log_upgrade "checksum: starting SHA-256 validation (expected=$sha256)"
     local actual_sha256
     actual_sha256=$(sha256sum_file "$zip_path")
+    log_upgrade "checksum: computed actual='${actual_sha256:-<unavailable>}'"
 
-    # Case-insensitive comparison (compatible with bash 3.x on macOS)
-    if [[ -n "$actual_sha256" ]] && ! echo "$actual_sha256" | grep -qi "^${sha256}$"; then
-      log "Checksum mismatch, skipping update"
-      log "Expected: $sha256"
-      log "Got: $actual_sha256"
+    if [[ -z "$actual_sha256" ]]; then
+      log_upgrade "checksum: skipped (no SHA-256 tool available)"
+    elif ! echo "$actual_sha256" | grep -qi "^${sha256}$"; then
+      # Case-insensitive comparison (compatible with bash 3.x on macOS)
+      log_both "Checksum mismatch, skipping update"
+      log_both "Expected: $sha256"
+      log_both "Got: $actual_sha256"
+      log_upgrade "checksum: FAIL -- dropping manifest and archive"
       rm -f "$PENDING_UPDATE" "$zip_path"
+      return 1
+    else
+      log_upgrade "checksum: OK"
+    fi
+  else
+    log_upgrade "checksum: skipped (manifest has no sha256)"
+  fi
+
+  # Pick the right extractor by archive type. No silent wrong-tool fallback
+  # (don't run tar on a zip).
+  local extractor
+  extractor=$(detect_archive_type "$zip_path")
+  log_upgrade "extractor: detected='${extractor:-<unknown>}' for '$zip_path'"
+  if [[ -z "$extractor" ]]; then
+    log_both "Error: Unknown archive type for $zip_path; preserving update for retry"
+    return 1
+  fi
+  if ! has_command "$extractor"; then
+    log_both "Error: Required extraction tool '$extractor' not found; install it and retry"
+    return 1
+  fi
+
+  # Staging path lives inside $VERSIONS_DIR so the final `mv` is a same-filesystem rename.
+  local staging="$VERSIONS_DIR/.$version.tmp.$$"
+  local old_dir="$VERSIONS_DIR/.$version.old.$$"
+
+  # Catch signals during extraction so Ctrl-C / SIGTERM doesn't leave a partial
+  # staging dir behind. (EXIT trap is not reliable for *function* returns, so we
+  # also do explicit cleanup before every error return below.)
+  # shellcheck disable=SC2064
+  trap "rm -rf \"$staging\" \"$old_dir\"; trap - INT TERM; exit 130" INT TERM
+
+  rm -rf "$staging"
+  if ! mkdir -p "$staging"; then
+    log_both "Error: Failed to create staging directory $staging"
+    trap - INT TERM
+    return 1
+  fi
+  log_upgrade "staging: created '$staging'"
+
+  log_both "Extracting to $staging..."
+  log_upgrade "extract: starting tool='$extractor' src='$zip_path' dst='$staging'"
+
+  if [[ "$extractor" == "unzip" ]]; then
+    if ! unzip -q "$zip_path" -d "$staging"; then
+      log_both "Error: Failed to extract $zip_path; preserving update for retry"
+      log_upgrade "extract: FAIL (unzip exit non-zero)"
+      rm -rf "$staging"
+      trap - INT TERM
+      return 1
+    fi
+  elif [[ "$extractor" == "ditto" ]]; then
+    # macOS: use ditto so the signed .app bundle is reconstructed exactly.
+    # No unzip fallback -- on failure we preserve the update for retry to
+    # avoid installing a structurally broken (and thus "damaged") bundle.
+    if ! ditto -x -k "$zip_path" "$staging"; then
+      log_both "Error: Failed to extract $zip_path; preserving update for retry"
+      log_upgrade "extract: FAIL (ditto exit non-zero)"
+      rm -rf "$staging"
+      trap - INT TERM
+      return 1
+    fi
+  else
+    if ! tar -xzf "$zip_path" -C "$staging"; then
+      log_both "Error: Failed to extract $zip_path; preserving update for retry"
+      log_upgrade "extract: FAIL (tar exit non-zero)"
+      rm -rf "$staging"
+      trap - INT TERM
+      return 1
+    fi
+  fi
+  log_upgrade "extract: OK"
+
+  # Resolve the binary against the staging dir and ensure it is executable.
+  local staged_binary
+  staged_binary=$(get_binary_path_in "$staging")
+  if [[ -z "$staged_binary" ]]; then
+    log_both "Error: No junie binary found in extracted payload; preserving update for retry"
+    rm -rf "$staging"
+    trap - INT TERM
+    return 1
+  fi
+  log_upgrade "binary: resolved '$staged_binary'"
+  chmod +x "$staged_binary" 2>/dev/null || true
+  if [[ ! -x "$staged_binary" ]]; then
+    log_both "Error: Extracted binary is not executable: $staged_binary"
+    rm -rf "$staging"
+    trap - INT TERM
+    return 1
+  fi
+
+  # Remove quarantine on macOS (best-effort)
+  xattr -dr com.apple.quarantine "$staging" 2>/dev/null || true
+
+  # Atomic swap: move existing version aside, then rename staging into place.
+  # We replace the whole tree so macOS .app bundles stay code-sign-consistent.
+  log_upgrade "atomic-move: target='$VERSIONS_DIR/$version'"
+  if [[ -e "$VERSIONS_DIR/$version" ]]; then
+    rm -rf "$old_dir"
+    log_upgrade "atomic-move: moving existing tree aside -> '$old_dir'"
+    if ! mv "$VERSIONS_DIR/$version" "$old_dir"; then
+      log_both "Error: Failed to move existing version aside"
+      log_upgrade "atomic-move: FAIL (mv existing -> old_dir)"
+      rm -rf "$staging"
+      trap - INT TERM
       return 1
     fi
   fi
 
-  # Extract to versions directory
-  local target_dir="$VERSIONS_DIR/$version"
-  mkdir -p "$target_dir"
-
-  log "Extracting to $target_dir..."
-
-  if has_command unzip; then
-    unzip -q -o "$zip_path" -d "$target_dir"
-  elif has_command tar; then
-    # Fallback for .tar.gz files
-    tar -xzf "$zip_path" -C "$target_dir"
-  else
-    log "Error: No extraction tool available (unzip or tar)"
+  if ! mv "$staging" "$VERSIONS_DIR/$version"; then
+    log_both "Error: Failed to install new version into $VERSIONS_DIR/$version"
+    log_upgrade "atomic-move: FAIL (mv staging -> target); attempting rollback"
+    # Try to restore previous version if we moved it aside
+    if [[ -e "$old_dir" && ! -e "$VERSIONS_DIR/$version" ]]; then
+      mv "$old_dir" "$VERSIONS_DIR/$version" 2>/dev/null \
+        && log_upgrade "atomic-move: rollback OK" \
+        || log_upgrade "atomic-move: rollback FAILED"
+    fi
+    rm -rf "$staging" "$old_dir"
+    trap - INT TERM
     return 1
   fi
+  log_upgrade "atomic-move: rename OK ('$staging' -> '$VERSIONS_DIR/$version')"
 
-  # Make binary executable
-  chmod +x "$target_dir/junie" 2>/dev/null || true
+  # Best-effort cleanup of the previous tree
+  rm -rf "$old_dir" 2>/dev/null || true
 
-  # Remove quarantine on macOS
-  xattr -dr com.apple.quarantine "$target_dir" 2>/dev/null || true
+  # Flip the current symlink atomically.
+  ln -sfn "$VERSIONS_DIR/$version" "$CURRENT_LINK"
+  log_upgrade "symlink: 'current' -> '$VERSIONS_DIR/$version'"
 
-  # Update current symlink atomically
-  ln -sfn "$target_dir" "$CURRENT_LINK"
-
-  # Cleanup
+  # Drop pending artifacts only after a fully successful swap.
   rm -f "$zip_path" "$PENDING_UPDATE"
+  log_upgrade "cleanup: removed zip='$zip_path' and manifest='$PENDING_UPDATE'"
 
-  log "Updated to version $version"
+  trap - INT TERM
+
+  log_both "Updated to version $version"
+  return 0
 }
 
 # === Resolve Version ===
@@ -330,7 +622,10 @@ handle_shim_commands() {
           current_version=$(basename "$(readlink "$CURRENT_LINK")")
         fi
         for v in "$VERSIONS_DIR"/*/; do
-          local vname=$(basename "$v")
+          local vname
+          vname=$(basename "$v")
+          # Skip transient staging dirs (.<v>.tmp.<pid>, .<v>.old.<pid>) defensively.
+          case "$vname" in .*) continue ;; esac
           if [[ "$vname" == "$current_version" ]]; then
             echo "  $vname (current)"
           else
@@ -360,8 +655,15 @@ main() {
   # Handle shim-specific commands
   handle_shim_commands "$@"
 
-  # Apply pending update if exists
-  apply_pending_update || true
+  # Defense-in-depth (JUNIE-2957): drop empty / unparseable update artifacts
+  # before either we or the launched binary react to them.
+  sanitize_pending_updates
+
+  # Apply pending update if present. On failure we deliberately do NOT abort:
+  # the previous version is still on disk (via the `current` symlink) and should run.
+  if ! apply_pending_update; then
+    log "Update not applied; continuing with current version"
+  fi
 
   # Resolve which version to run
   local version
@@ -393,34 +695,73 @@ SHIM_EOF
 chmod +x "$JUNIE_BIN/junie"
 
 # Download and install binary
+# Always re-download and overwrite the target version directory, regardless of
+# whether it already exists. This avoids reusing a previously cached broken or
+# partial install for the same version.
 TARGET_DIR="$JUNIE_DATA/versions/$VERSION"
-if [[ ! -d "$TARGET_DIR" ]]; then
-  TMP_ZIP=$(mktemp)
+TMP_ZIP=$(mktemp)
 
-  log "Downloading $DOWNLOAD_URL"
-  curl -fSL --progress-bar -o "$TMP_ZIP" "$DOWNLOAD_URL"
+log "Downloading $DOWNLOAD_URL"
+curl -fSL --progress-bar -o "$TMP_ZIP" "$DOWNLOAD_URL"
 
-  # Verify checksum
-  if [[ -n "$SHA256" ]]; then
-    actual_sha256=$(sha256sum_file "$TMP_ZIP")
-    if [[ -n "$actual_sha256" ]]; then
-      if ! echo "$actual_sha256" | grep -qi "^${SHA256}$"; then
-        log_error "Checksum verification failed!"
-        log_error "Expected: $SHA256"
-        log_error "Got: $actual_sha256"
-        rm -f "$TMP_ZIP"
-        exit 1
-      fi
-      log "Checksum verified"
+# Verify checksum
+if [[ -n "$SHA256" ]]; then
+  actual_sha256=$(sha256sum_file "$TMP_ZIP")
+  if [[ -n "$actual_sha256" ]]; then
+    if ! echo "$actual_sha256" | grep -qi "^${SHA256}$"; then
+      log_error "Checksum verification failed!"
+      log_error "Expected: $SHA256"
+      log_error "Got: $actual_sha256"
+      rm -f "$TMP_ZIP"
+      exit 1
     fi
+    log "Checksum verified"
   fi
-
-  mkdir -p "$TARGET_DIR"
-  unzip -q -o "$TMP_ZIP" -d "$TARGET_DIR"
-  rm -f "$TMP_ZIP"
-
-  [[ "$OS_NAME" == "macos" ]] && xattr -dr com.apple.quarantine "$TARGET_DIR" 2>/dev/null || true
 fi
+
+# Extract to a staging dir on the same filesystem as $TARGET_DIR, validate the
+# resolved binary, then atomically rename into place. This mirrors the shim's
+# robust extraction so an interrupted install never leaves a half-extracted tree.
+STAGING="$JUNIE_DATA/versions/.$VERSION.tmp.$$"
+trap 'rm -rf "$STAGING"' EXIT INT TERM
+rm -rf "$STAGING"
+mkdir -p "$STAGING"
+# On macOS use ditto so the signed .app bundle is reconstructed exactly;
+# on Linux use unzip. (See require_extractor above for the rationale.)
+if [[ "$OS_NAME" == "macos" ]]; then
+  ditto -x -k "$TMP_ZIP" "$STAGING"
+else
+  unzip -q "$TMP_ZIP" -d "$STAGING"
+fi
+rm -f "$TMP_ZIP"
+
+# Validate the extracted binary (inline equivalent of get_binary_path_in).
+if [[ -d "$STAGING/Applications/junie.app" ]]; then
+  STAGED_BIN="$STAGING/Applications/junie.app/Contents/MacOS/junie"
+elif [[ -f "$STAGING/junie/bin/junie" ]]; then
+  STAGED_BIN="$STAGING/junie/bin/junie"
+elif [[ -f "$STAGING/junie" ]]; then
+  STAGED_BIN="$STAGING/junie"
+else
+  STAGED_BIN=""
+fi
+if [[ -z "$STAGED_BIN" ]]; then
+  log_error "No junie binary found in downloaded payload"
+  exit 1
+fi
+chmod +x "$STAGED_BIN" 2>/dev/null || true
+if [[ ! -x "$STAGED_BIN" ]]; then
+  log_error "Extracted binary is not executable: $STAGED_BIN"
+  exit 1
+fi
+
+[[ "$OS_NAME" == "macos" ]] && xattr -dr com.apple.quarantine "$STAGING" 2>/dev/null || true
+
+# Remove any existing (possibly broken) version directory, then atomically
+# rename the validated staging tree into the final version directory.
+rm -rf "$TARGET_DIR"
+mv "$STAGING" "$TARGET_DIR"
+trap - EXIT INT TERM
 
 # Set current version
 ln -sfn "$TARGET_DIR" "$JUNIE_DATA/current"

--- a/templates/install.sh.template
+++ b/templates/install.sh.template
@@ -18,18 +18,30 @@ JUNIE_DATA="$HOME/.local/share/junie"
 log() { echo "[Junie] $*"; }
 log_error() { echo "[Junie] ERROR: $*" >&2; }
 
-# Ensure required tools are available before we start downloading anything.
-# We fail early with an actionable, OS-aware install hint so users on minimal
-# images (containers, fresh VPS, etc.) aren't stuck staring at a cryptic
-# `unzip: command not found` halfway through the install.
-require_unzip() {
+# Ensure the required archive extractor is available before we start downloading
+# anything. We fail early with an actionable, OS-aware install hint so users on
+# minimal images (containers, fresh VPS, etc.) aren't stuck staring at a cryptic
+# `command not found` halfway through the install.
+#
+# On macOS we require `ditto` (Apple's archive tool, part of the base install)
+# so notarized/code-signed .app bundles are reconstructed exactly. Info-ZIP
+# `unzip` mangles symlinks/permissions/xattrs and breaks the signature seal,
+# which on Apple Silicon yields "is damaged and cannot be opened." On Linux we
+# require `unzip`.
+require_extractor() {
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    if command -v ditto > /dev/null 2>&1; then
+      return 0
+    fi
+    log_error "'ditto' is required to install Junie on macOS, but it was not found in PATH."
+    log_error "'ditto' ships with macOS at /usr/bin/ditto; ensure /usr/bin is on your PATH and re-run this installer."
+    exit 1
+  fi
   if command -v unzip > /dev/null 2>&1; then
     return 0
   fi
   log_error "'unzip' is required to install Junie, but it was not found in PATH."
-  if [[ "$(uname -s)" == "Darwin" ]]; then
-    log_error "Install it with: brew install unzip"
-  elif command -v apt-get > /dev/null 2>&1; then
+  if command -v apt-get > /dev/null 2>&1; then
     log_error "Install it with: sudo apt-get update && sudo apt-get install -y unzip"
   elif command -v dnf > /dev/null 2>&1; then
     log_error "Install it with: sudo dnf install -y unzip"
@@ -46,7 +58,7 @@ require_unzip() {
   fi
   exit 1
 }
-require_unzip
+require_extractor
 
 # Calculate SHA-256 checksum
 sha256sum_file() {
@@ -186,7 +198,13 @@ STAGING="$JUNIE_DATA/versions/.$VERSION.tmp.$$"
 trap 'rm -rf "$STAGING"' EXIT INT TERM
 rm -rf "$STAGING"
 mkdir -p "$STAGING"
-unzip -q "$TMP_ZIP" -d "$STAGING"
+# On macOS use ditto so the signed .app bundle is reconstructed exactly;
+# on Linux use unzip. (See require_extractor above for the rationale.)
+if [[ "$OS_NAME" == "macos" ]]; then
+  ditto -x -k "$TMP_ZIP" "$STAGING"
+else
+  unzip -q "$TMP_ZIP" -d "$STAGING"
+fi
 rm -f "$TMP_ZIP"
 
 # Validate the extracted binary (inline equivalent of get_binary_path_in).

--- a/templates/junie.shim.sh
+++ b/templates/junie.shim.sh
@@ -113,18 +113,32 @@ get_binary_path() {
   get_binary_path_in "$VERSIONS_DIR/$version"
 }
 
+# Pick the zip extractor for the current OS. On macOS we must use `ditto`
+# (Apple's archive tool) so notarized/code-signed .app bundles are
+# reconstructed exactly -- symlinks, permissions, and extended attributes
+# intact. Info-ZIP `unzip` mangles those and breaks the signature seal, which
+# on Apple Silicon yields "is damaged and cannot be opened." On Linux we keep
+# `unzip`.
+zip_extractor() {
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    echo "ditto"
+  else
+    echo "unzip"
+  fi
+}
+
 # Detect the archive type of $1 by extension or magic bytes.
-# Echoes "unzip", "tar", or "" if unknown.
+# Echoes the zip extractor ("unzip" or "ditto"), "tar", or "" if unknown.
 detect_archive_type() {
   local file="$1"
   case "$file" in
-    *.zip|*.ZIP) echo "unzip"; return 0 ;;
+    *.zip|*.ZIP) zip_extractor; return 0 ;;
     *.tar.gz|*.tgz|*.TAR.GZ|*.TGZ) echo "tar"; return 0 ;;
   esac
   local magic
   magic=$(head -c 4 "$file" 2>/dev/null | od -An -tx1 | tr -d ' \n' 2>/dev/null || echo "")
   case "$magic" in
-    504b0304*|504b0506*|504b0708*) echo "unzip" ;;
+    504b0304*|504b0506*|504b0708*) zip_extractor ;;
     1f8b*)                          echo "tar"   ;;
     *)                              echo ""      ;;
   esac
@@ -274,6 +288,17 @@ apply_pending_update() {
     if ! unzip -q "$zip_path" -d "$staging"; then
       log_both "Error: Failed to extract $zip_path; preserving update for retry"
       log_upgrade "extract: FAIL (unzip exit non-zero)"
+      rm -rf "$staging"
+      trap - INT TERM
+      return 1
+    fi
+  elif [[ "$extractor" == "ditto" ]]; then
+    # macOS: use ditto so the signed .app bundle is reconstructed exactly.
+    # No unzip fallback -- on failure we preserve the update for retry to
+    # avoid installing a structurally broken (and thus "damaged") bundle.
+    if ! ditto -x -k "$zip_path" "$staging"; then
+      log_both "Error: Failed to extract $zip_path; preserving update for retry"
+      log_upgrade "extract: FAIL (ditto exit non-zero)"
       rm -rf "$staging"
       trap - INT TERM
       return 1

--- a/tests/shim_atomic_extract.sh
+++ b/tests/shim_atomic_extract.sh
@@ -133,6 +133,38 @@ write_manifest() {
 EOF
 }
 
+# Stub `uname` so the shim's `zip_extractor` resolves zips to `ditto` (Darwin
+# path). Only `uname -s` is overridden; any other invocation defers to the real
+# binary. Pair with `stub_ditto_*` and remove with `unstub_macos`.
+stub_macos_uname() {
+  uname() {
+    if [[ "${1:-}" == "-s" ]]; then echo "Darwin"; return 0; fi
+    command uname "$@"
+  }
+}
+
+# Stub `ditto -x -k SRC DST` to extract via unzip (which CI has), emulating a
+# working macOS ditto. Any other ditto invocation is a no-op success.
+stub_ditto_ok() {
+  ditto() {
+    if [[ "${1:-}" == "-x" && "${2:-}" == "-k" ]]; then
+      unzip -q "$3" -d "$4"
+      return $?
+    fi
+    return 0
+  }
+}
+
+# Stub `ditto` so extraction always fails, emulating a broken/incompatible
+# ditto on macOS (exercises the new ditto branch's fail-and-preserve path).
+stub_ditto_fail() {
+  ditto() { return 1; }
+}
+
+unstub_macos() {
+  unset -f uname ditto 2>/dev/null || true
+}
+
 # Seed a pre-existing version dir, used as "the previous working version".
 seed_version() {
   local v="$1"; shift
@@ -298,6 +330,58 @@ test_poisoned_manifest() {
   teardown_env
 }
 
+# 9. macOS happy path: zip resolves to `ditto`, bundle swapped, current flipped.
+test_macos_ditto_happy_path() {
+  setup_env "macos_ditto_happy_path"
+  stub_macos_uname
+  stub_ditto_ok
+  seed_version "1.0"
+  local zip="$JUNIE_DATA/updates/u.zip"
+  make_app_zip "$zip"
+  write_manifest "1.1" "$zip"
+
+  # Sanity: on the stubbed-Darwin path a zip must resolve to the ditto extractor.
+  assert '[[ "$(detect_archive_type "$zip")" == "ditto" ]]' "zip must resolve to ditto on macOS" || { unstub_macos; teardown_env; return; }
+
+  apply_pending_update
+  local rc=$?
+
+  assert "[[ $rc -eq 0 ]]" "apply_pending_update should succeed via ditto" || { unstub_macos; teardown_env; return; }
+  assert "[[ -x \"$JUNIE_DATA/versions/1.1/Applications/junie.app/Contents/MacOS/junie\" ]]" "new app binary must exist after ditto extract" || { unstub_macos; teardown_env; return; }
+  assert '[[ "$(readlink "$JUNIE_DATA/current")" == "$JUNIE_DATA/versions/1.1" ]]' "current must point at 1.1" || { unstub_macos; teardown_env; return; }
+  assert "[[ ! -f \"$JUNIE_DATA/updates/pending-update.json\" ]]" "manifest must be deleted after success" || { unstub_macos; teardown_env; return; }
+  assert "[[ ! -f \"$zip\" ]]" "zip must be deleted after success" || { unstub_macos; teardown_env; return; }
+  assert "! ls -A \"$JUNIE_DATA/versions\"/.*.tmp.* > /dev/null 2>&1" "no staging dirs left behind" || { unstub_macos; teardown_env; return; }
+  ok
+  unstub_macos
+  teardown_env
+}
+
+# 10. macOS ditto failure -> no unzip fallback, artifacts preserved for retry.
+test_macos_ditto_failure_preserves_artifacts() {
+  setup_env "macos_ditto_failure"
+  stub_macos_uname
+  stub_ditto_fail
+  seed_version "1.0"
+  local zip="$JUNIE_DATA/updates/u.zip"
+  make_app_zip "$zip"
+  write_manifest "1.1" "$zip"
+
+  apply_pending_update
+  local rc=$?
+
+  assert "[[ $rc -ne 0 ]]" "apply_pending_update must fail when ditto fails" || { unstub_macos; teardown_env; return; }
+  assert "[[ ! -d \"$JUNIE_DATA/versions/1.1\" ]]" "no partial 1.1 dir must be created" || { unstub_macos; teardown_env; return; }
+  assert "[[ -x \"$JUNIE_DATA/versions/1.0/junie/bin/junie\" ]]" "previous version must remain intact" || { unstub_macos; teardown_env; return; }
+  assert '[[ "$(readlink "$JUNIE_DATA/current")" == "$JUNIE_DATA/versions/1.0" ]]' "current must still point at 1.0" || { unstub_macos; teardown_env; return; }
+  assert "[[ -f \"$JUNIE_DATA/updates/pending-update.json\" ]]" "manifest must be preserved for retry" || { unstub_macos; teardown_env; return; }
+  assert "[[ -f \"$zip\" ]]" "zip must be preserved for retry" || { unstub_macos; teardown_env; return; }
+  assert "! ls -A \"$JUNIE_DATA/versions\"/.*.tmp.* > /dev/null 2>&1" "no staging dirs left behind" || { unstub_macos; teardown_env; return; }
+  ok
+  unstub_macos
+  teardown_env
+}
+
 # 8. No pending update -> no-op success
 test_no_pending_update() {
   setup_env "no_pending_update"
@@ -319,6 +403,8 @@ test_corrupt_zip_preserves_artifacts
 test_missing_unzip_tool
 test_validation_failure_no_binary
 test_poisoned_manifest
+test_macos_ditto_happy_path
+test_macos_ditto_failure_preserves_artifacts
 test_no_pending_update
 
 echo ""


### PR DESCRIPTION
## Problem

On macOS, installing via `curl … | bash` (and self-updates) produced **"is damaged and cannot be opened"** on Apple Silicon, even though the exact same release `.zip` opens and runs fine when downloaded from the browser.

Root cause: the installer/shim expanded the notarized, code‑signed `.app` bundle with Info‑ZIP **`unzip`**, which does not faithfully reconstruct symlinks, permission bits, and extended attributes. That breaks the code‑signature seal, and arm64 macOS refuses to launch an app with an invalid signature. The browser path works because Archive Utility uses Apple's **`ditto`/AppleArchive** machinery, which reconstructs the bundle exactly.

## Change

Make **only the zip‑extraction step OS‑aware** in the single shared shim and the installer:

- macOS (`uname -s` = `Darwin`): extract zips with `ditto -x -k`.
- Linux: keep `unzip` for zip, `tar` for `tar.gz` — unchanged.
- On `ditto` failure the pending update + zip are **preserved for retry** (no `unzip` fallback, no broken bundle installed).
- Installer preflight now requires `ditto` on macOS and `unzip` on Linux (with package‑manager hints).
- Everything else (checksum verification, staging → atomic rename swap, rollback, `current` symlink flip, quarantine stripping) is reused unchanged.

No separate macOS shim file — most of the shim is reused; only the extractor differs by OS.

```mermaid
flowchart TD
    S[shared shim / installer] -->|uname Darwin, zip| D[ditto -x -k]
    S -->|Linux, zip| U[unzip]
    S -->|tar.gz| T[tar]
    D -->|fail| P[preserve update for retry]
    D -->|ok| A[junie.app signature intact]
```

## Files

- `templates/junie.shim.sh` — `zip_extractor()` (ditto on Darwin, unzip otherwise), wired into `detect_archive_type`; new `ditto` extraction branch in `apply_pending_update` with fail‑and‑preserve semantics.
- `templates/install.sh.template` — `require_unzip` → `require_extractor` (OS‑aware preflight); OS‑branched initial extraction.
- `install.sh`, `install-eap.sh`, `install-nightly.sh`, `install-experimental.sh`, `install.ps1` — **regenerated** from templates via `templates/generate.sh` (not hand‑edited). Regeneration also brings the root scripts back in sync with already‑committed template changes so `generate.sh --check` stays green.
- `tests/shim_atomic_extract.sh` — added `test_macos_ditto_happy_path` and `test_macos_ditto_failure_preserves_artifacts` (stub `uname`=Darwin and `ditto`, since CI runs on Linux).

## Verification

- `bash tests/shim_atomic_extract.sh` → all scenarios pass, including both new macOS/ditto cases.
- `bash -n` clean for the templates and all four generated `install*.sh`.
- `./templates/generate.sh --check` reports scripts up to date with no unresolved `{{…}}` placeholders.

🤖 Co-authored with Junie