### PR TITLE
fix(shim): stop Windows shim from deleting valid update manifests (^| caret bug)

### DIFF
--- a/install-eap.ps1
+++ b/install-eap.ps1
@@ -204,7 +204,7 @@ set "PROCESSING=%UPDATES_DIR%\pending-update.json.processing"
 ::: binary's own update path with CWD as a working-dir hint.
 if exist "%PENDING_UPDATE%" (
   set "PEND_OK="
-  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '%PENDING_UPDATE%' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c ^| ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PEND_OK=%%V"
+  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '%PENDING_UPDATE%' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c | ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PEND_OK=%%V"
   if /i not "!PEND_OK!"=="ok" (
     echo [Junie] Removing invalid update artifact: %PENDING_UPDATE% 1>&2
     del /f /q "%PENDING_UPDATE%" 2>nul
@@ -212,7 +212,7 @@ if exist "%PENDING_UPDATE%" (
 )
 if exist "!PROCESSING!" (
   set "PROC_OK="
-  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '!PROCESSING!' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c ^| ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PROC_OK=%%V"
+  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '!PROCESSING!' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c | ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PROC_OK=%%V"
   if /i not "!PROC_OK!"=="ok" (
     echo [Junie] Removing invalid update artifact: !PROCESSING! 1>&2
     del /f /q "!PROCESSING!" 2>nul

--- a/install-experimental.ps1
+++ b/install-experimental.ps1
@@ -204,7 +204,7 @@ set "PROCESSING=%UPDATES_DIR%\pending-update.json.processing"
 ::: binary's own update path with CWD as a working-dir hint.
 if exist "%PENDING_UPDATE%" (
   set "PEND_OK="
-  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '%PENDING_UPDATE%' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c ^| ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PEND_OK=%%V"
+  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '%PENDING_UPDATE%' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c | ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PEND_OK=%%V"
   if /i not "!PEND_OK!"=="ok" (
     echo [Junie] Removing invalid update artifact: %PENDING_UPDATE% 1>&2
     del /f /q "%PENDING_UPDATE%" 2>nul
@@ -212,7 +212,7 @@ if exist "%PENDING_UPDATE%" (
 )
 if exist "!PROCESSING!" (
   set "PROC_OK="
-  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '!PROCESSING!' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c ^| ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PROC_OK=%%V"
+  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '!PROCESSING!' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c | ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PROC_OK=%%V"
   if /i not "!PROC_OK!"=="ok" (
     echo [Junie] Removing invalid update artifact: !PROCESSING! 1>&2
     del /f /q "!PROCESSING!" 2>nul

--- a/install-nightly.ps1
+++ b/install-nightly.ps1
@@ -204,7 +204,7 @@ set "PROCESSING=%UPDATES_DIR%\pending-update.json.processing"
 ::: binary's own update path with CWD as a working-dir hint.
 if exist "%PENDING_UPDATE%" (
   set "PEND_OK="
-  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '%PENDING_UPDATE%' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c ^| ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PEND_OK=%%V"
+  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '%PENDING_UPDATE%' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c | ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PEND_OK=%%V"
   if /i not "!PEND_OK!"=="ok" (
     echo [Junie] Removing invalid update artifact: %PENDING_UPDATE% 1>&2
     del /f /q "%PENDING_UPDATE%" 2>nul
@@ -212,7 +212,7 @@ if exist "%PENDING_UPDATE%" (
 )
 if exist "!PROCESSING!" (
   set "PROC_OK="
-  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '!PROCESSING!' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c ^| ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PROC_OK=%%V"
+  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '!PROCESSING!' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c | ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PROC_OK=%%V"
   if /i not "!PROC_OK!"=="ok" (
     echo [Junie] Removing invalid update artifact: !PROCESSING! 1>&2
     del /f /q "!PROCESSING!" 2>nul

--- a/install.ps1
+++ b/install.ps1
@@ -204,7 +204,7 @@ set "PROCESSING=%UPDATES_DIR%\pending-update.json.processing"
 ::: binary's own update path with CWD as a working-dir hint.
 if exist "%PENDING_UPDATE%" (
   set "PEND_OK="
-  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '%PENDING_UPDATE%' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c ^| ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PEND_OK=%%V"
+  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '%PENDING_UPDATE%' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c | ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PEND_OK=%%V"
   if /i not "!PEND_OK!"=="ok" (
     echo [Junie] Removing invalid update artifact: %PENDING_UPDATE% 1>&2
     del /f /q "%PENDING_UPDATE%" 2>nul
@@ -212,7 +212,7 @@ if exist "%PENDING_UPDATE%" (
 )
 if exist "!PROCESSING!" (
   set "PROC_OK="
-  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '!PROCESSING!' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c ^| ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PROC_OK=%%V"
+  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '!PROCESSING!' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c | ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PROC_OK=%%V"
   if /i not "!PROC_OK!"=="ok" (
     echo [Junie] Removing invalid update artifact: !PROCESSING! 1>&2
     del /f /q "!PROCESSING!" 2>nul

--- a/templates/junie.shim.bat
+++ b/templates/junie.shim.bat
@@ -33,7 +33,7 @@ set "PROCESSING=%UPDATES_DIR%\pending-update.json.processing"
 ::: binary's own update path with CWD as a working-dir hint.
 if exist "%PENDING_UPDATE%" (
   set "PEND_OK="
-  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '%PENDING_UPDATE%' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c ^| ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PEND_OK=%%V"
+  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '%PENDING_UPDATE%' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c | ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PEND_OK=%%V"
   if /i not "!PEND_OK!"=="ok" (
     echo [Junie] Removing invalid update artifact: %PENDING_UPDATE% 1>&2
     del /f /q "%PENDING_UPDATE%" 2>nul
@@ -41,7 +41,7 @@ if exist "%PENDING_UPDATE%" (
 )
 if exist "!PROCESSING!" (
   set "PROC_OK="
-  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '!PROCESSING!' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c ^| ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PROC_OK=%%V"
+  for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "try { $c = Get-Content -Raw -LiteralPath '!PROCESSING!' -ErrorAction Stop; if ([string]::IsNullOrWhiteSpace($c)) { 'bad' } else { $j = $c | ConvertFrom-Json; if ($j.version -and $j.zipPath) { 'ok' } else { 'bad' } } } catch { 'bad' }"`) do set "PROC_OK=%%V"
   if /i not "!PROC_OK!"=="ok" (
     echo [Junie] Removing invalid update artifact: !PROCESSING! 1>&2
     del /f /q "!PROCESSING!" 2>nul


### PR DESCRIPTION
## Problem

On Windows, the install-repo shim template `templates/junie.shim.bat` prints

```
[Junie] Removing invalid update artifact: ...\pending-update.json
```

on **every** launch — the binary downloads the update and writes a valid `pending-update.json`, but the shim deletes it before it can be applied, so the update is never installed.

### Root cause

The JUNIE-2957 sanitization block validates the manifest with PowerShell using `$c ^| ConvertFrom-Json`. Inside a `` for /f (`...`) `` backtick context the `^` is **not** an escape — it is passed literally to PowerShell, which then fails at *parse* time:

```
Unexpected token '^' in expression or statement.
```

Because it is a parse error, the surrounding `try { } catch { 'bad' }` never runs, PowerShell prints nothing, so `PEND_OK` / `PROC_OK` stay empty, the `if /i not "!PEND_OK!"=="ok"` test passes, and the shim `del`s a perfectly valid manifest. The same defect was present in the `.processing` check.

## Fix

Change `^|` → bare `|` in **both** PowerShell validation commands (lines 36 and 44 — the `pending-update.json` and `.processing` checks). This matches every other PowerShell call in the same file, which already uses a bare `|` inside the same backtick context.

Line 175 (`echo [Junie] Run: irm https://junie.jetbrains.com/install.ps1 ^| iex`) is intentionally **left untouched** — it is inside a plain `echo`, where `^|` correctly prints a literal `|`.

## Verification

This fix was reproduced and verified live on a Windows machine: with `^|` the shim deletes the valid manifest (`Removing invalid update artifact`); with bare `|` the manifest survives and the pending update is applied on the next launch.

## Note

This is the install-repo counterpart of the same fix made to the canonical shim in `JetBrains/junie-agent` (`ej-app/cli-standalone/package/shim/junie.bat`, PR #6672). Both copies of the template carried the identical caret bug and both need fixing so freshly installed and updated shims are correct.