### PR TITLE
Fix one-shot channel installs: set -e --<channel> drop + disable auto-update

### DIFF
--- a/install-eap.ps1
+++ b/install-eap.ps1
@@ -344,7 +344,11 @@ for %%A in (%*) do (
     )
   )
 )
-endlocal & "%JUNIE_EXE%" %FILTERED_ARGS%
+:: One-shot launch: force JUNIE_SKIP_UPDATE_CHECK=1 across endlocal so this
+:: temporary channel build never checks for, downloads, or stages an update that
+:: would clobber the user's persisted default channel (the binary honors it via
+:: SystemOptionsGroup).
+endlocal & set "JUNIE_SKIP_UPDATE_CHECK=1" & "%JUNIE_EXE%" %FILTERED_ARGS%
 goto :eof
 
 :after_channel_oneshot

--- a/install-eap.sh
+++ b/install-eap.sh
@@ -634,7 +634,9 @@ filter_args() {
       --*)
         # Skip bareword channel flags (--eap, --nightly, ...), data-driven.
         for c in $KNOWN_CHANNELS; do
-          [[ "$arg" == "--$c" ]] && skip=1
+          if [[ "$arg" == "--$c" ]]; then
+            skip=1
+          fi
         done
         ;;
     esac
@@ -712,7 +714,9 @@ detect_channel_flag() {
         ;;
       --*)
         for c in $KNOWN_CHANNELS; do
-          [[ "$arg" == "--$c" ]] && REQUESTED_CHANNEL="$c"
+          if [[ "$arg" == "--$c" ]]; then
+            REQUESTED_CHANNEL="$c"
+          fi
         done
         ;;
     esac
@@ -807,6 +811,13 @@ run_channel_oneshot() {
 
   export EJ_RUNNER_PWD="${EJ_RUNNER_PWD:-$(pwd)}"
   export JUNIE_DATA="$JUNIE_DATA"
+
+  # Disable the binary's auto-update for one-shot channel runs. This build is
+  # launched only for the current invocation, so it must never check for,
+  # download, or stage an update -- doing so would race with and clobber the
+  # user's persisted default channel. The binary honors JUNIE_SKIP_UPDATE_CHECK
+  # (see SystemOptionsGroup / AutoUpdateService).
+  export JUNIE_SKIP_UPDATE_CHECK=1
 
   filter_args "$@"
   exec "$binary" ${FILTERED_ARGS[@]+"${FILTERED_ARGS[@]}"}

--- a/install-experimental.ps1
+++ b/install-experimental.ps1
@@ -344,7 +344,11 @@ for %%A in (%*) do (
     )
   )
 )
-endlocal & "%JUNIE_EXE%" %FILTERED_ARGS%
+:: One-shot launch: force JUNIE_SKIP_UPDATE_CHECK=1 across endlocal so this
+:: temporary channel build never checks for, downloads, or stages an update that
+:: would clobber the user's persisted default channel (the binary honors it via
+:: SystemOptionsGroup).
+endlocal & set "JUNIE_SKIP_UPDATE_CHECK=1" & "%JUNIE_EXE%" %FILTERED_ARGS%
 goto :eof
 
 :after_channel_oneshot

--- a/install-experimental.sh
+++ b/install-experimental.sh
@@ -634,7 +634,9 @@ filter_args() {
       --*)
         # Skip bareword channel flags (--eap, --nightly, ...), data-driven.
         for c in $KNOWN_CHANNELS; do
-          [[ "$arg" == "--$c" ]] && skip=1
+          if [[ "$arg" == "--$c" ]]; then
+            skip=1
+          fi
         done
         ;;
     esac
@@ -712,7 +714,9 @@ detect_channel_flag() {
         ;;
       --*)
         for c in $KNOWN_CHANNELS; do
-          [[ "$arg" == "--$c" ]] && REQUESTED_CHANNEL="$c"
+          if [[ "$arg" == "--$c" ]]; then
+            REQUESTED_CHANNEL="$c"
+          fi
         done
         ;;
     esac
@@ -807,6 +811,13 @@ run_channel_oneshot() {
 
   export EJ_RUNNER_PWD="${EJ_RUNNER_PWD:-$(pwd)}"
   export JUNIE_DATA="$JUNIE_DATA"
+
+  # Disable the binary's auto-update for one-shot channel runs. This build is
+  # launched only for the current invocation, so it must never check for,
+  # download, or stage an update -- doing so would race with and clobber the
+  # user's persisted default channel. The binary honors JUNIE_SKIP_UPDATE_CHECK
+  # (see SystemOptionsGroup / AutoUpdateService).
+  export JUNIE_SKIP_UPDATE_CHECK=1
 
   filter_args "$@"
   exec "$binary" ${FILTERED_ARGS[@]+"${FILTERED_ARGS[@]}"}

--- a/install-nightly.ps1
+++ b/install-nightly.ps1
@@ -344,7 +344,11 @@ for %%A in (%*) do (
     )
   )
 )
-endlocal & "%JUNIE_EXE%" %FILTERED_ARGS%
+:: One-shot launch: force JUNIE_SKIP_UPDATE_CHECK=1 across endlocal so this
+:: temporary channel build never checks for, downloads, or stages an update that
+:: would clobber the user's persisted default channel (the binary honors it via
+:: SystemOptionsGroup).
+endlocal & set "JUNIE_SKIP_UPDATE_CHECK=1" & "%JUNIE_EXE%" %FILTERED_ARGS%
 goto :eof
 
 :after_channel_oneshot

--- a/install-nightly.sh
+++ b/install-nightly.sh
@@ -634,7 +634,9 @@ filter_args() {
       --*)
         # Skip bareword channel flags (--eap, --nightly, ...), data-driven.
         for c in $KNOWN_CHANNELS; do
-          [[ "$arg" == "--$c" ]] && skip=1
+          if [[ "$arg" == "--$c" ]]; then
+            skip=1
+          fi
         done
         ;;
     esac
@@ -712,7 +714,9 @@ detect_channel_flag() {
         ;;
       --*)
         for c in $KNOWN_CHANNELS; do
-          [[ "$arg" == "--$c" ]] && REQUESTED_CHANNEL="$c"
+          if [[ "$arg" == "--$c" ]]; then
+            REQUESTED_CHANNEL="$c"
+          fi
         done
         ;;
     esac
@@ -807,6 +811,13 @@ run_channel_oneshot() {
 
   export EJ_RUNNER_PWD="${EJ_RUNNER_PWD:-$(pwd)}"
   export JUNIE_DATA="$JUNIE_DATA"
+
+  # Disable the binary's auto-update for one-shot channel runs. This build is
+  # launched only for the current invocation, so it must never check for,
+  # download, or stage an update -- doing so would race with and clobber the
+  # user's persisted default channel. The binary honors JUNIE_SKIP_UPDATE_CHECK
+  # (see SystemOptionsGroup / AutoUpdateService).
+  export JUNIE_SKIP_UPDATE_CHECK=1
 
   filter_args "$@"
   exec "$binary" ${FILTERED_ARGS[@]+"${FILTERED_ARGS[@]}"}

--- a/install.ps1
+++ b/install.ps1
@@ -344,7 +344,11 @@ for %%A in (%*) do (
     )
   )
 )
-endlocal & "%JUNIE_EXE%" %FILTERED_ARGS%
+:: One-shot launch: force JUNIE_SKIP_UPDATE_CHECK=1 across endlocal so this
+:: temporary channel build never checks for, downloads, or stages an update that
+:: would clobber the user's persisted default channel (the binary honors it via
+:: SystemOptionsGroup).
+endlocal & set "JUNIE_SKIP_UPDATE_CHECK=1" & "%JUNIE_EXE%" %FILTERED_ARGS%
 goto :eof
 
 :after_channel_oneshot

--- a/install.sh
+++ b/install.sh
@@ -634,7 +634,9 @@ filter_args() {
       --*)
         # Skip bareword channel flags (--eap, --nightly, ...), data-driven.
         for c in $KNOWN_CHANNELS; do
-          [[ "$arg" == "--$c" ]] && skip=1
+          if [[ "$arg" == "--$c" ]]; then
+            skip=1
+          fi
         done
         ;;
     esac
@@ -712,7 +714,9 @@ detect_channel_flag() {
         ;;
       --*)
         for c in $KNOWN_CHANNELS; do
-          [[ "$arg" == "--$c" ]] && REQUESTED_CHANNEL="$c"
+          if [[ "$arg" == "--$c" ]]; then
+            REQUESTED_CHANNEL="$c"
+          fi
         done
         ;;
     esac
@@ -807,6 +811,13 @@ run_channel_oneshot() {
 
   export EJ_RUNNER_PWD="${EJ_RUNNER_PWD:-$(pwd)}"
   export JUNIE_DATA="$JUNIE_DATA"
+
+  # Disable the binary's auto-update for one-shot channel runs. This build is
+  # launched only for the current invocation, so it must never check for,
+  # download, or stage an update -- doing so would race with and clobber the
+  # user's persisted default channel. The binary honors JUNIE_SKIP_UPDATE_CHECK
+  # (see SystemOptionsGroup / AutoUpdateService).
+  export JUNIE_SKIP_UPDATE_CHECK=1
 
   filter_args "$@"
   exec "$binary" ${FILTERED_ARGS[@]+"${FILTERED_ARGS[@]}"}

--- a/templates/junie.shim.bat
+++ b/templates/junie.shim.bat
@@ -147,7 +147,11 @@ for %%A in (%*) do (
     )
   )
 )
-endlocal & "%JUNIE_EXE%" %FILTERED_ARGS%
+:: One-shot launch: force JUNIE_SKIP_UPDATE_CHECK=1 across endlocal so this
+:: temporary channel build never checks for, downloads, or stages an update that
+:: would clobber the user's persisted default channel (the binary honors it via
+:: SystemOptionsGroup).
+endlocal & set "JUNIE_SKIP_UPDATE_CHECK=1" & "%JUNIE_EXE%" %FILTERED_ARGS%
 goto :eof
 
 :after_channel_oneshot

--- a/templates/junie.shim.sh
+++ b/templates/junie.shim.sh
@@ -447,7 +447,9 @@ filter_args() {
       --*)
         # Skip bareword channel flags (--eap, --nightly, ...), data-driven.
         for c in $KNOWN_CHANNELS; do
-          [[ "$arg" == "--$c" ]] && skip=1
+          if [[ "$arg" == "--$c" ]]; then
+            skip=1
+          fi
         done
         ;;
     esac
@@ -525,7 +527,9 @@ detect_channel_flag() {
         ;;
       --*)
         for c in $KNOWN_CHANNELS; do
-          [[ "$arg" == "--$c" ]] && REQUESTED_CHANNEL="$c"
+          if [[ "$arg" == "--$c" ]]; then
+            REQUESTED_CHANNEL="$c"
+          fi
         done
         ;;
     esac
@@ -620,6 +624,13 @@ run_channel_oneshot() {
 
   export EJ_RUNNER_PWD="${EJ_RUNNER_PWD:-$(pwd)}"
   export JUNIE_DATA="$JUNIE_DATA"
+
+  # Disable the binary's auto-update for one-shot channel runs. This build is
+  # launched only for the current invocation, so it must never check for,
+  # download, or stage an update -- doing so would race with and clobber the
+  # user's persisted default channel. The binary honors JUNIE_SKIP_UPDATE_CHECK
+  # (see SystemOptionsGroup / AutoUpdateService).
+  export JUNIE_SKIP_UPDATE_CHECK=1
 
   filter_args "$@"
   exec "$binary" ${FILTERED_ARGS[@]+"${FILTERED_ARGS[@]}"}


### PR DESCRIPTION
## What

Fixes the install scripts / shim so one-shot custom-channel runs work correctly.

- **`set -e` bug:** `detect_channel_flag` and `filter_args` ended on a trailing `[[ "$arg" == "--$c" ]] && ...` test whose last iteration (`--experimental`) returns non-zero. Under `set -euo pipefail` that made the whole bash shim exit before `run_channel_oneshot`, so `junie --eap` (and other `--<channel>`) was silently dropped on macOS/Linux. Replaced with explicit `if [[ ... ]]; then ... fi` (exempt from `set -e`). Windows `cmd.exe` had no `set -e` equivalent and was unaffected.
- **Disable auto-update for one-shot/custom builds:** export `JUNIE_SKIP_UPDATE_CHECK=1` when launching a one-shot channel build (bash `run_channel_oneshot` and the Windows `.bat` one-shot launch line) so a temporary build never checks for, downloads, or stages an update that would clobber the user's persisted default channel. The binary already honors this env var via `SystemOptionsGroup` / `AutoUpdateService`.

## Files

Updated `templates/junie.shim.sh` and `templates/junie.shim.bat` and regenerated all 8 installers (`install*.sh` / `install*.ps1`).

## Verification

- `bash -n` passes on all `install*.sh`.
- Under `set -euo pipefail`, `detect_channel_flag --eap --version` now yields `REQUESTED_CHANNEL=eap` and continues into the one-shot path.
- Each `install*.sh` now shows 0 buggy loops, 2 `if`-fixed loops, and the `JUNIE_SKIP_UPDATE_CHECK` export.