### PR TITLE
Fix silent shim abort: make detect_channel_flag return 0

### DIFF
--- a/install-eap.sh
+++ b/install-eap.sh
@@ -717,6 +717,10 @@ detect_channel_flag() {
         ;;
     esac
   done
+  # Always succeed: the loop's last command is a `[[ ]]` test that returns 1 for
+  # any non-channel arg (e.g. `--help`). Since this function is called as a bare
+  # command under `set -e`, that stray exit status would abort the whole shim.
+  return 0
 }
 
 is_known_channel() {

--- a/install-experimental.sh
+++ b/install-experimental.sh
@@ -717,6 +717,10 @@ detect_channel_flag() {
         ;;
     esac
   done
+  # Always succeed: the loop's last command is a `[[ ]]` test that returns 1 for
+  # any non-channel arg (e.g. `--help`). Since this function is called as a bare
+  # command under `set -e`, that stray exit status would abort the whole shim.
+  return 0
 }
 
 is_known_channel() {

--- a/install-nightly.sh
+++ b/install-nightly.sh
@@ -717,6 +717,10 @@ detect_channel_flag() {
         ;;
     esac
   done
+  # Always succeed: the loop's last command is a `[[ ]]` test that returns 1 for
+  # any non-channel arg (e.g. `--help`). Since this function is called as a bare
+  # command under `set -e`, that stray exit status would abort the whole shim.
+  return 0
 }
 
 is_known_channel() {

--- a/install.sh
+++ b/install.sh
@@ -717,6 +717,10 @@ detect_channel_flag() {
         ;;
     esac
   done
+  # Always succeed: the loop's last command is a `[[ ]]` test that returns 1 for
+  # any non-channel arg (e.g. `--help`). Since this function is called as a bare
+  # command under `set -e`, that stray exit status would abort the whole shim.
+  return 0
 }
 
 is_known_channel() {

--- a/templates/junie.shim.sh
+++ b/templates/junie.shim.sh
@@ -530,6 +530,10 @@ detect_channel_flag() {
         ;;
     esac
   done
+  # Always succeed: the loop's last command is a `[[ ]]` test that returns 1 for
+  # any non-channel arg (e.g. `--help`). Since this function is called as a bare
+  # command under `set -e`, that stray exit status would abort the whole shim.
+  return 0
 }
 
 is_known_channel() {

--- a/tests/shim_channel_switch.sh
+++ b/tests/shim_channel_switch.sh
@@ -108,6 +108,13 @@ test_detect_channel_flag() {
   detect_channel_flag --help
   assert "[[ -z \"\$REQUESTED_CHANNEL\" ]]" "no channel flag -> empty" || { teardown_env; return; }
 
+  # Regression: a non-channel arg must NOT leave a non-zero exit status. The
+  # function is called as a bare command under `set -e` in main(); if its last
+  # command is a failing `[[ ]]` test the whole shim aborts silently (no output,
+  # exit 1) — e.g. `junie --help` or any normal launch.
+  detect_channel_flag --help; local rc=$?
+  assert "[[ $rc -eq 0 ]]" "non-channel arg must return success (set -e safety)" || { teardown_env; return; }
+
   detect_channel_flag --eap
   assert "[[ \"\$REQUESTED_CHANNEL\" == eap ]]" "--eap -> eap" || { teardown_env; return; }
 


### PR DESCRIPTION
## Problem

The Junie launcher shim fails silently — even `junie --help` exits with code `1` and prints **nothing**. This makes the `junie-github-action` unable to launch Junie at all (observed in CI).

## Root cause

The shim runs under `set -euo pipefail` and `main()` invokes `detect_channel_flag "$@"` as a **bare command**. That function's loop ends on:

```bash
[[ "$arg" == "--$c" ]] && REQUESTED_CHANNEL="$c"
```

For any argument that is **not** a channel flag (e.g. `--help`, or the real args the action passes), the last executed command is a `[[ ]]` comparison that evaluates to **false → exit status 1**. That becomes the function's return value, and because it is called as a plain command under `set -e`, bash **aborts the entire shim immediately with exit 1 and no output**.

## Fix

Add an explicit `return 0` at the end of `detect_channel_flag` so its exit status no longer depends on the trailing comparison.

- Patched the canonical source `templates/junie.shim.sh`.
- Regenerated `install.sh`, `install-eap.sh`, `install-nightly.sh`, `install-experimental.sh` via `templates/generate.sh` (these are marked "DO NOT EDIT — generated").
- Added a regression test in `tests/shim_channel_switch.sh` asserting `detect_channel_flag` returns success for a non-channel arg.

## Verification

- `./templates/generate.sh --check` → all installer scripts up to date.
- `bash tests/shim_channel_switch.sh` → 6/6 PASS (including the new regression assertion).
- Functional check: non-channel args no longer abort under `set -e`, while `--eap`/`--channel=…` detection still works.

Co-authored-by: Junie <junie@jetbrains.com>