### PR TITLE
Sync Managed Shim Fixes

### DIFF
--- a/install-eap.ps1
+++ b/install-eap.ps1
@@ -198,6 +198,8 @@ if ($ONESHOT) {
 @echo off
 setlocal enabledelayedexpansion
 
+:: JUNIE_MANAGED_SHIM
+::
 :: Junie CLI Shim for Windows
 ::
 :: This script is the entry point for Junie CLI. It handles:
@@ -313,7 +315,6 @@ if not exist "!JUNIE_EXE!" (
   exit /b 1
 )
 if not defined EJ_RUNNER_PWD set "EJ_RUNNER_PWD=%CD%"
-set "JUNIE_DATA=%JUNIE_DATA%"
 
 :: Filter out channel flags from args and launch the requested build directly.
 :: cmd splits `--channel=<name>` into the tokens `--channel` and `<name>`, so
@@ -344,11 +345,12 @@ for %%A in (%*) do (
     )
   )
 )
-:: One-shot launch: force JUNIE_SKIP_UPDATE_CHECK=1 across endlocal so this
-:: temporary channel build never checks for, downloads, or stages an update that
-:: would clobber the user's persisted default channel (the binary honors it via
-:: SystemOptionsGroup).
-endlocal & set "JUNIE_SKIP_UPDATE_CHECK=1" & "%JUNIE_EXE%" %FILTERED_ARGS%
+:: One-shot launch: pass EJ_RUNNER_PWD and JUNIE_DATA across endlocal, but NOT
+:: JUNIE_SHIM_PATH -- a temporary channel build must never adopt or self-update
+:: the default shim. Also force JUNIE_SKIP_UPDATE_CHECK=1 so this temporary build
+:: never checks for, downloads, or stages an update that would clobber the user's
+:: persisted default channel (the binary honors it via SystemOptionsGroup).
+endlocal & set "EJ_RUNNER_PWD=%EJ_RUNNER_PWD%" & set "JUNIE_DATA=%JUNIE_DATA%" & set "JUNIE_SKIP_UPDATE_CHECK=1" & "%JUNIE_EXE%" %FILTERED_ARGS%
 goto :eof
 
 :after_channel_oneshot
@@ -537,7 +539,10 @@ for %%A in (%*) do (
   )
 )
 
-endlocal & "%JUNIE_EXE%" %FILTERED_ARGS%
+:: Restore environment but pass important variables to the exe.
+:: Export this shim's own absolute path (%~f0) so the binary can refresh it in
+:: place during auto-update (see ShimUpdater on the binary side).
+endlocal & set "EJ_RUNNER_PWD=%EJ_RUNNER_PWD%" & set "JUNIE_DATA=%JUNIE_DATA%" & set "JUNIE_SHIM_PATH=%~f0" & "%JUNIE_EXE%" %FILTERED_ARGS%
 '@
   [System.IO.File]::WriteAllText($SHIM_PATH, $SHIM_CONTENT)
 

--- a/install-eap.sh
+++ b/install-eap.sh
@@ -187,6 +187,8 @@ if [[ -z "$ONESHOT" ]]; then
 cat > "$JUNIE_BIN/junie" << 'SHIM_EOF'
 #!/bin/bash
 #
+# JUNIE_MANAGED_SHIM
+#
 # Junie CLI Shim
 #
 # This script is the entry point for Junie CLI. It handles:
@@ -636,6 +638,7 @@ filter_args() {
         for c in $KNOWN_CHANNELS; do
           if [[ "$arg" == "--$c" ]]; then
             skip=1
+            break
           fi
         done
         ;;
@@ -716,6 +719,7 @@ detect_channel_flag() {
         for c in $KNOWN_CHANNELS; do
           if [[ "$arg" == "--$c" ]]; then
             REQUESTED_CHANNEL="$c"
+            break
           fi
         done
         ;;
@@ -868,6 +872,15 @@ main() {
 
   # Set JUNIE_DATA for the app to know where data is stored
   export JUNIE_DATA="$JUNIE_DATA"
+
+  # Resolve and export this shim's own absolute path so the binary can refresh
+  # it in place during auto-update (see ShimUpdater on the binary side).
+  local self="$0"
+  case "$self" in
+    /*) ;;
+    *) self="$(cd "$(dirname "$self")" && pwd)/$(basename "$self")" ;;
+  esac
+  export JUNIE_SHIM_PATH="$self"
 
   # Filter out shim-specific args and execute
   filter_args "$@"

--- a/install-experimental.ps1
+++ b/install-experimental.ps1
@@ -198,6 +198,8 @@ if ($ONESHOT) {
 @echo off
 setlocal enabledelayedexpansion
 
+:: JUNIE_MANAGED_SHIM
+::
 :: Junie CLI Shim for Windows
 ::
 :: This script is the entry point for Junie CLI. It handles:
@@ -313,7 +315,6 @@ if not exist "!JUNIE_EXE!" (
   exit /b 1
 )
 if not defined EJ_RUNNER_PWD set "EJ_RUNNER_PWD=%CD%"
-set "JUNIE_DATA=%JUNIE_DATA%"
 
 :: Filter out channel flags from args and launch the requested build directly.
 :: cmd splits `--channel=<name>` into the tokens `--channel` and `<name>`, so
@@ -344,11 +345,12 @@ for %%A in (%*) do (
     )
   )
 )
-:: One-shot launch: force JUNIE_SKIP_UPDATE_CHECK=1 across endlocal so this
-:: temporary channel build never checks for, downloads, or stages an update that
-:: would clobber the user's persisted default channel (the binary honors it via
-:: SystemOptionsGroup).
-endlocal & set "JUNIE_SKIP_UPDATE_CHECK=1" & "%JUNIE_EXE%" %FILTERED_ARGS%
+:: One-shot launch: pass EJ_RUNNER_PWD and JUNIE_DATA across endlocal, but NOT
+:: JUNIE_SHIM_PATH -- a temporary channel build must never adopt or self-update
+:: the default shim. Also force JUNIE_SKIP_UPDATE_CHECK=1 so this temporary build
+:: never checks for, downloads, or stages an update that would clobber the user's
+:: persisted default channel (the binary honors it via SystemOptionsGroup).
+endlocal & set "EJ_RUNNER_PWD=%EJ_RUNNER_PWD%" & set "JUNIE_DATA=%JUNIE_DATA%" & set "JUNIE_SKIP_UPDATE_CHECK=1" & "%JUNIE_EXE%" %FILTERED_ARGS%
 goto :eof
 
 :after_channel_oneshot
@@ -537,7 +539,10 @@ for %%A in (%*) do (
   )
 )
 
-endlocal & "%JUNIE_EXE%" %FILTERED_ARGS%
+:: Restore environment but pass important variables to the exe.
+:: Export this shim's own absolute path (%~f0) so the binary can refresh it in
+:: place during auto-update (see ShimUpdater on the binary side).
+endlocal & set "EJ_RUNNER_PWD=%EJ_RUNNER_PWD%" & set "JUNIE_DATA=%JUNIE_DATA%" & set "JUNIE_SHIM_PATH=%~f0" & "%JUNIE_EXE%" %FILTERED_ARGS%
 '@
   [System.IO.File]::WriteAllText($SHIM_PATH, $SHIM_CONTENT)
 

--- a/install-experimental.sh
+++ b/install-experimental.sh
@@ -187,6 +187,8 @@ if [[ -z "$ONESHOT" ]]; then
 cat > "$JUNIE_BIN/junie" << 'SHIM_EOF'
 #!/bin/bash
 #
+# JUNIE_MANAGED_SHIM
+#
 # Junie CLI Shim
 #
 # This script is the entry point for Junie CLI. It handles:
@@ -636,6 +638,7 @@ filter_args() {
         for c in $KNOWN_CHANNELS; do
           if [[ "$arg" == "--$c" ]]; then
             skip=1
+            break
           fi
         done
         ;;
@@ -716,6 +719,7 @@ detect_channel_flag() {
         for c in $KNOWN_CHANNELS; do
           if [[ "$arg" == "--$c" ]]; then
             REQUESTED_CHANNEL="$c"
+            break
           fi
         done
         ;;
@@ -868,6 +872,15 @@ main() {
 
   # Set JUNIE_DATA for the app to know where data is stored
   export JUNIE_DATA="$JUNIE_DATA"
+
+  # Resolve and export this shim's own absolute path so the binary can refresh
+  # it in place during auto-update (see ShimUpdater on the binary side).
+  local self="$0"
+  case "$self" in
+    /*) ;;
+    *) self="$(cd "$(dirname "$self")" && pwd)/$(basename "$self")" ;;
+  esac
+  export JUNIE_SHIM_PATH="$self"
 
   # Filter out shim-specific args and execute
   filter_args "$@"

--- a/install-nightly.ps1
+++ b/install-nightly.ps1
@@ -198,6 +198,8 @@ if ($ONESHOT) {
 @echo off
 setlocal enabledelayedexpansion
 
+:: JUNIE_MANAGED_SHIM
+::
 :: Junie CLI Shim for Windows
 ::
 :: This script is the entry point for Junie CLI. It handles:
@@ -313,7 +315,6 @@ if not exist "!JUNIE_EXE!" (
   exit /b 1
 )
 if not defined EJ_RUNNER_PWD set "EJ_RUNNER_PWD=%CD%"
-set "JUNIE_DATA=%JUNIE_DATA%"
 
 :: Filter out channel flags from args and launch the requested build directly.
 :: cmd splits `--channel=<name>` into the tokens `--channel` and `<name>`, so
@@ -344,11 +345,12 @@ for %%A in (%*) do (
     )
   )
 )
-:: One-shot launch: force JUNIE_SKIP_UPDATE_CHECK=1 across endlocal so this
-:: temporary channel build never checks for, downloads, or stages an update that
-:: would clobber the user's persisted default channel (the binary honors it via
-:: SystemOptionsGroup).
-endlocal & set "JUNIE_SKIP_UPDATE_CHECK=1" & "%JUNIE_EXE%" %FILTERED_ARGS%
+:: One-shot launch: pass EJ_RUNNER_PWD and JUNIE_DATA across endlocal, but NOT
+:: JUNIE_SHIM_PATH -- a temporary channel build must never adopt or self-update
+:: the default shim. Also force JUNIE_SKIP_UPDATE_CHECK=1 so this temporary build
+:: never checks for, downloads, or stages an update that would clobber the user's
+:: persisted default channel (the binary honors it via SystemOptionsGroup).
+endlocal & set "EJ_RUNNER_PWD=%EJ_RUNNER_PWD%" & set "JUNIE_DATA=%JUNIE_DATA%" & set "JUNIE_SKIP_UPDATE_CHECK=1" & "%JUNIE_EXE%" %FILTERED_ARGS%
 goto :eof
 
 :after_channel_oneshot
@@ -537,7 +539,10 @@ for %%A in (%*) do (
   )
 )
 
-endlocal & "%JUNIE_EXE%" %FILTERED_ARGS%
+:: Restore environment but pass important variables to the exe.
+:: Export this shim's own absolute path (%~f0) so the binary can refresh it in
+:: place during auto-update (see ShimUpdater on the binary side).
+endlocal & set "EJ_RUNNER_PWD=%EJ_RUNNER_PWD%" & set "JUNIE_DATA=%JUNIE_DATA%" & set "JUNIE_SHIM_PATH=%~f0" & "%JUNIE_EXE%" %FILTERED_ARGS%
 '@
   [System.IO.File]::WriteAllText($SHIM_PATH, $SHIM_CONTENT)
 

--- a/install-nightly.sh
+++ b/install-nightly.sh
@@ -187,6 +187,8 @@ if [[ -z "$ONESHOT" ]]; then
 cat > "$JUNIE_BIN/junie" << 'SHIM_EOF'
 #!/bin/bash
 #
+# JUNIE_MANAGED_SHIM
+#
 # Junie CLI Shim
 #
 # This script is the entry point for Junie CLI. It handles:
@@ -636,6 +638,7 @@ filter_args() {
         for c in $KNOWN_CHANNELS; do
           if [[ "$arg" == "--$c" ]]; then
             skip=1
+            break
           fi
         done
         ;;
@@ -716,6 +719,7 @@ detect_channel_flag() {
         for c in $KNOWN_CHANNELS; do
           if [[ "$arg" == "--$c" ]]; then
             REQUESTED_CHANNEL="$c"
+            break
           fi
         done
         ;;
@@ -868,6 +872,15 @@ main() {
 
   # Set JUNIE_DATA for the app to know where data is stored
   export JUNIE_DATA="$JUNIE_DATA"
+
+  # Resolve and export this shim's own absolute path so the binary can refresh
+  # it in place during auto-update (see ShimUpdater on the binary side).
+  local self="$0"
+  case "$self" in
+    /*) ;;
+    *) self="$(cd "$(dirname "$self")" && pwd)/$(basename "$self")" ;;
+  esac
+  export JUNIE_SHIM_PATH="$self"
 
   # Filter out shim-specific args and execute
   filter_args "$@"

--- a/install.ps1
+++ b/install.ps1
@@ -198,6 +198,8 @@ if ($ONESHOT) {
 @echo off
 setlocal enabledelayedexpansion
 
+:: JUNIE_MANAGED_SHIM
+::
 :: Junie CLI Shim for Windows
 ::
 :: This script is the entry point for Junie CLI. It handles:
@@ -313,7 +315,6 @@ if not exist "!JUNIE_EXE!" (
   exit /b 1
 )
 if not defined EJ_RUNNER_PWD set "EJ_RUNNER_PWD=%CD%"
-set "JUNIE_DATA=%JUNIE_DATA%"
 
 :: Filter out channel flags from args and launch the requested build directly.
 :: cmd splits `--channel=<name>` into the tokens `--channel` and `<name>`, so
@@ -344,11 +345,12 @@ for %%A in (%*) do (
     )
   )
 )
-:: One-shot launch: force JUNIE_SKIP_UPDATE_CHECK=1 across endlocal so this
-:: temporary channel build never checks for, downloads, or stages an update that
-:: would clobber the user's persisted default channel (the binary honors it via
-:: SystemOptionsGroup).
-endlocal & set "JUNIE_SKIP_UPDATE_CHECK=1" & "%JUNIE_EXE%" %FILTERED_ARGS%
+:: One-shot launch: pass EJ_RUNNER_PWD and JUNIE_DATA across endlocal, but NOT
+:: JUNIE_SHIM_PATH -- a temporary channel build must never adopt or self-update
+:: the default shim. Also force JUNIE_SKIP_UPDATE_CHECK=1 so this temporary build
+:: never checks for, downloads, or stages an update that would clobber the user's
+:: persisted default channel (the binary honors it via SystemOptionsGroup).
+endlocal & set "EJ_RUNNER_PWD=%EJ_RUNNER_PWD%" & set "JUNIE_DATA=%JUNIE_DATA%" & set "JUNIE_SKIP_UPDATE_CHECK=1" & "%JUNIE_EXE%" %FILTERED_ARGS%
 goto :eof
 
 :after_channel_oneshot
@@ -537,7 +539,10 @@ for %%A in (%*) do (
   )
 )
 
-endlocal & "%JUNIE_EXE%" %FILTERED_ARGS%
+:: Restore environment but pass important variables to the exe.
+:: Export this shim's own absolute path (%~f0) so the binary can refresh it in
+:: place during auto-update (see ShimUpdater on the binary side).
+endlocal & set "EJ_RUNNER_PWD=%EJ_RUNNER_PWD%" & set "JUNIE_DATA=%JUNIE_DATA%" & set "JUNIE_SHIM_PATH=%~f0" & "%JUNIE_EXE%" %FILTERED_ARGS%
 '@
   [System.IO.File]::WriteAllText($SHIM_PATH, $SHIM_CONTENT)
 

--- a/install.sh
+++ b/install.sh
@@ -187,6 +187,8 @@ if [[ -z "$ONESHOT" ]]; then
 cat > "$JUNIE_BIN/junie" << 'SHIM_EOF'
 #!/bin/bash
 #
+# JUNIE_MANAGED_SHIM
+#
 # Junie CLI Shim
 #
 # This script is the entry point for Junie CLI. It handles:
@@ -636,6 +638,7 @@ filter_args() {
         for c in $KNOWN_CHANNELS; do
           if [[ "$arg" == "--$c" ]]; then
             skip=1
+            break
           fi
         done
         ;;
@@ -716,6 +719,7 @@ detect_channel_flag() {
         for c in $KNOWN_CHANNELS; do
           if [[ "$arg" == "--$c" ]]; then
             REQUESTED_CHANNEL="$c"
+            break
           fi
         done
         ;;
@@ -868,6 +872,15 @@ main() {
 
   # Set JUNIE_DATA for the app to know where data is stored
   export JUNIE_DATA="$JUNIE_DATA"
+
+  # Resolve and export this shim's own absolute path so the binary can refresh
+  # it in place during auto-update (see ShimUpdater on the binary side).
+  local self="$0"
+  case "$self" in
+    /*) ;;
+    *) self="$(cd "$(dirname "$self")" && pwd)/$(basename "$self")" ;;
+  esac
+  export JUNIE_SHIM_PATH="$self"
 
   # Filter out shim-specific args and execute
   filter_args "$@"

--- a/templates/junie.shim.bat
+++ b/templates/junie.shim.bat
@@ -1,6 +1,8 @@
 @echo off
 setlocal enabledelayedexpansion
 
+:: JUNIE_MANAGED_SHIM
+::
 :: Junie CLI Shim for Windows
 ::
 :: This script is the entry point for Junie CLI. It handles:
@@ -116,7 +118,6 @@ if not exist "!JUNIE_EXE!" (
   exit /b 1
 )
 if not defined EJ_RUNNER_PWD set "EJ_RUNNER_PWD=%CD%"
-set "JUNIE_DATA=%JUNIE_DATA%"
 
 :: Filter out channel flags from args and launch the requested build directly.
 :: cmd splits `--channel=<name>` into the tokens `--channel` and `<name>`, so
@@ -147,11 +148,12 @@ for %%A in (%*) do (
     )
   )
 )
-:: One-shot launch: force JUNIE_SKIP_UPDATE_CHECK=1 across endlocal so this
-:: temporary channel build never checks for, downloads, or stages an update that
-:: would clobber the user's persisted default channel (the binary honors it via
-:: SystemOptionsGroup).
-endlocal & set "JUNIE_SKIP_UPDATE_CHECK=1" & "%JUNIE_EXE%" %FILTERED_ARGS%
+:: One-shot launch: pass EJ_RUNNER_PWD and JUNIE_DATA across endlocal, but NOT
+:: JUNIE_SHIM_PATH -- a temporary channel build must never adopt or self-update
+:: the default shim. Also force JUNIE_SKIP_UPDATE_CHECK=1 so this temporary build
+:: never checks for, downloads, or stages an update that would clobber the user's
+:: persisted default channel (the binary honors it via SystemOptionsGroup).
+endlocal & set "EJ_RUNNER_PWD=%EJ_RUNNER_PWD%" & set "JUNIE_DATA=%JUNIE_DATA%" & set "JUNIE_SKIP_UPDATE_CHECK=1" & "%JUNIE_EXE%" %FILTERED_ARGS%
 goto :eof
 
 :after_channel_oneshot
@@ -340,4 +342,7 @@ for %%A in (%*) do (
   )
 )
 
-endlocal & "%JUNIE_EXE%" %FILTERED_ARGS%
+:: Restore environment but pass important variables to the exe.
+:: Export this shim's own absolute path (%~f0) so the binary can refresh it in
+:: place during auto-update (see ShimUpdater on the binary side).
+endlocal & set "EJ_RUNNER_PWD=%EJ_RUNNER_PWD%" & set "JUNIE_DATA=%JUNIE_DATA%" & set "JUNIE_SHIM_PATH=%~f0" & "%JUNIE_EXE%" %FILTERED_ARGS%

--- a/templates/junie.shim.sh
+++ b/templates/junie.shim.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 #
+# JUNIE_MANAGED_SHIM
+#
 # Junie CLI Shim
 #
 # This script is the entry point for Junie CLI. It handles:
@@ -449,6 +451,7 @@ filter_args() {
         for c in $KNOWN_CHANNELS; do
           if [[ "$arg" == "--$c" ]]; then
             skip=1
+            break
           fi
         done
         ;;
@@ -529,6 +532,7 @@ detect_channel_flag() {
         for c in $KNOWN_CHANNELS; do
           if [[ "$arg" == "--$c" ]]; then
             REQUESTED_CHANNEL="$c"
+            break
           fi
         done
         ;;
@@ -681,6 +685,15 @@ main() {
 
   # Set JUNIE_DATA for the app to know where data is stored
   export JUNIE_DATA="$JUNIE_DATA"
+
+  # Resolve and export this shim's own absolute path so the binary can refresh
+  # it in place during auto-update (see ShimUpdater on the binary side).
+  local self="$0"
+  case "$self" in
+    /*) ;;
+    *) self="$(cd "$(dirname "$self")" && pwd)/$(basename "$self")" ;;
+  esac
+  export JUNIE_SHIM_PATH="$self"
 
   # Filter out shim-specific args and execute
   filter_args "$@"


### PR DESCRIPTION
Syncs the published CLI installer templates with the managed shim source in matterhorn (`ej-app/cli-standalone/package/shim`).

## Changes
- Add `JUNIE_MANAGED_SHIM` marker to `templates/junie.shim.sh` and `templates/junie.shim.bat`.
- Add `break` in the two `KNOWN_CHANNELS` detection loops in `junie.shim.sh` (stop iterating once a channel flag matches).
- Export `JUNIE_SHIM_PATH` self-path so the binary can refresh the shim in place during auto-update (`ShimUpdater`).
- In `junie.shim.bat`, carry `EJ_RUNNER_PWD`/`JUNIE_DATA` across `endlocal` (and `JUNIE_SHIM_PATH=%~f0` on the default launch); one-shot channel launches intentionally omit `JUNIE_SHIM_PATH`.
- Regenerate all `install*.sh`/`install*.ps1` from the updated templates (`{{CHANNELS}}` placeholders preserved).

Companion to JetBrains/junie-agent#6681.