### PR TITLE
Sync Managed Shim Fixes

### DIFF
--- a/install-experimental.sh
+++ b/install-experimental.sh
@@ -959,7 +959,32 @@ else
     exit 1
   fi
 
-  [[ "$OS_NAME" == "macos" ]] && xattr -dr com.apple.quarantine "$STAGING" 2>/dev/null || true
+  # macOS Gatekeeper handling. We sign AND notarize, so the bundle normally
+  # passes Gatekeeper with quarantine intact and nothing needs to be stripped.
+  # As a defensive fallback we verify acceptance during install and only strip
+  # quarantine if Gatekeeper would actually reject this copy (e.g. a browser
+  # re-download that got re-quarantined). Gating the strip behind a *failed*
+  # assessment preserves Gatekeeper's protection in the normal case while still
+  # producing a working install in the edge case.
+  if [[ "$OS_NAME" == "macos" && -d "$STAGING/Applications/junie.app" ]]; then
+    APP="$STAGING/Applications/junie.app"
+    # Is the signature structurally valid? (Informational only; never abort.)
+    if ! /usr/bin/codesign --verify --deep --strict "$APP" > /dev/null 2>&1; then
+      log "Warning: code signature could not be verified for $APP"
+    fi
+    # Would Gatekeeper let it execute? This also checks notarization, so it
+    # reflects the real first-launch user experience.
+    if /usr/sbin/spctl --assess --type execute "$APP" > /dev/null 2>&1; then
+      log "Gatekeeper assessment passed"
+    else
+      log "Gatekeeper assessment failed; stripping quarantine as a fallback"
+      # Call Apple's xattr by absolute path so a foreign `xattr` earlier on PATH
+      # cannot shadow it (that binary may lack -r; see JUNIE-2906), and fully
+      # silence it (Apple's xattr prints its usage text to stdout, so 2>/dev/null
+      # alone would still leak noise). `|| true` keeps `set -e` from aborting.
+      [[ -x /usr/bin/xattr ]] && /usr/bin/xattr -dr com.apple.quarantine "$APP" > /dev/null 2>&1 || true
+    fi
+  fi
 
   # Remove any existing (possibly broken) version directory, then atomically
   # rename the validated staging tree into the final version directory.

--- a/install-nightly.sh
+++ b/install-nightly.sh
@@ -959,7 +959,32 @@ else
     exit 1
   fi
 
-  [[ "$OS_NAME" == "macos" ]] && xattr -dr com.apple.quarantine "$STAGING" 2>/dev/null || true
+  # macOS Gatekeeper handling. We sign AND notarize, so the bundle normally
+  # passes Gatekeeper with quarantine intact and nothing needs to be stripped.
+  # As a defensive fallback we verify acceptance during install and only strip
+  # quarantine if Gatekeeper would actually reject this copy (e.g. a browser
+  # re-download that got re-quarantined). Gating the strip behind a *failed*
+  # assessment preserves Gatekeeper's protection in the normal case while still
+  # producing a working install in the edge case.
+  if [[ "$OS_NAME" == "macos" && -d "$STAGING/Applications/junie.app" ]]; then
+    APP="$STAGING/Applications/junie.app"
+    # Is the signature structurally valid? (Informational only; never abort.)
+    if ! /usr/bin/codesign --verify --deep --strict "$APP" > /dev/null 2>&1; then
+      log "Warning: code signature could not be verified for $APP"
+    fi
+    # Would Gatekeeper let it execute? This also checks notarization, so it
+    # reflects the real first-launch user experience.
+    if /usr/sbin/spctl --assess --type execute "$APP" > /dev/null 2>&1; then
+      log "Gatekeeper assessment passed"
+    else
+      log "Gatekeeper assessment failed; stripping quarantine as a fallback"
+      # Call Apple's xattr by absolute path so a foreign `xattr` earlier on PATH
+      # cannot shadow it (that binary may lack -r; see JUNIE-2906), and fully
+      # silence it (Apple's xattr prints its usage text to stdout, so 2>/dev/null
+      # alone would still leak noise). `|| true` keeps `set -e` from aborting.
+      [[ -x /usr/bin/xattr ]] && /usr/bin/xattr -dr com.apple.quarantine "$APP" > /dev/null 2>&1 || true
+    fi
+  fi
 
   # Remove any existing (possibly broken) version directory, then atomically
   # rename the validated staging tree into the final version directory.

--- a/templates/generate.sh
+++ b/templates/generate.sh
@@ -48,18 +48,52 @@ render() {
   CHANNEL="$channel" URL="$url" SHIM_FILE="$shim_file" \
   TEMPLATE_NAME="$template_name" CHANNELS="$channels" \
   awk '
+    # Return 1 if channel "ch" is in the comma-separated list "lst".
+    function in_channel_list(ch, lst,    n, arr, i) {
+      n = split(lst, arr, ",")
+      for (i = 1; i <= n; i++) {
+        gsub(/[ \t]/, "", arr[i])
+        if (arr[i] == ch) return 1
+      }
+      return 0
+    }
     BEGIN {
       channel       = ENVIRON["CHANNEL"]
       url           = ENVIRON["URL"]
       shim_file     = ENVIRON["SHIM_FILE"]
       template_name = ENVIRON["TEMPLATE_NAME"]
       channels      = ENVIRON["CHANNELS"]
+      include       = 1
     }
     NR == 1 {
       print
       print "# DO NOT EDIT — generated from templates/" template_name " by templates/generate.sh"
       next
     }
+    # Channel-conditional blocks (single source for all channels, but selective
+    # output): {{#channels:a,b}} ... {{/channels}} includes the body only for
+    # the listed channels; {{^channels:a,b}} ... {{/channels}} includes it only
+    # for the others. Blocks must not be nested. The directive lines themselves
+    # are never emitted.
+    /^[ \t]*\{\{#channels:.*\}\}[ \t]*$/ {
+      list = $0
+      sub(/^[ \t]*\{\{#channels:/, "", list)
+      sub(/\}\}[ \t]*$/, "", list)
+      include = in_channel_list(channel, list)
+      next
+    }
+    /^[ \t]*\{\{\^channels:.*\}\}[ \t]*$/ {
+      list = $0
+      sub(/^[ \t]*\{\{\^channels:/, "", list)
+      sub(/\}\}[ \t]*$/, "", list)
+      include = in_channel_list(channel, list) ? 0 : 1
+      next
+    }
+    /^[ \t]*\{\{\/channels\}\}[ \t]*$/ {
+      include = 1
+      next
+    }
+    include == 0 { next }
     $0 == "{{SHIM}}" {
       # The shim is inlined verbatim except for {{CHANNELS}}, which lets the
       # shim derive its channel list from channels.tsv (single source of truth).

--- a/templates/install.sh.template
+++ b/templates/install.sh.template
@@ -256,7 +256,37 @@ else
     exit 1
   fi
 
+{{#channels:nightly,experimental}}
+  # macOS Gatekeeper handling. We sign AND notarize, so the bundle normally
+  # passes Gatekeeper with quarantine intact and nothing needs to be stripped.
+  # As a defensive fallback we verify acceptance during install and only strip
+  # quarantine if Gatekeeper would actually reject this copy (e.g. a browser
+  # re-download that got re-quarantined). Gating the strip behind a *failed*
+  # assessment preserves Gatekeeper's protection in the normal case while still
+  # producing a working install in the edge case.
+  if [[ "$OS_NAME" == "macos" && -d "$STAGING/Applications/junie.app" ]]; then
+    APP="$STAGING/Applications/junie.app"
+    # Is the signature structurally valid? (Informational only; never abort.)
+    if ! /usr/bin/codesign --verify --deep --strict "$APP" > /dev/null 2>&1; then
+      log "Warning: code signature could not be verified for $APP"
+    fi
+    # Would Gatekeeper let it execute? This also checks notarization, so it
+    # reflects the real first-launch user experience.
+    if /usr/sbin/spctl --assess --type execute "$APP" > /dev/null 2>&1; then
+      log "Gatekeeper assessment passed"
+    else
+      log "Gatekeeper assessment failed; stripping quarantine as a fallback"
+      # Call Apple's xattr by absolute path so a foreign `xattr` earlier on PATH
+      # cannot shadow it (that binary may lack -r; see JUNIE-2906), and fully
+      # silence it (Apple's xattr prints its usage text to stdout, so 2>/dev/null
+      # alone would still leak noise). `|| true` keeps `set -e` from aborting.
+      [[ -x /usr/bin/xattr ]] && /usr/bin/xattr -dr com.apple.quarantine "$APP" > /dev/null 2>&1 || true
+    fi
+  fi
+{{/channels}}
+{{^channels:nightly,experimental}}
   [[ "$OS_NAME" == "macos" ]] && xattr -dr com.apple.quarantine "$STAGING" 2>/dev/null || true
+{{/channels}}
 
   # Remove any existing (possibly broken) version directory, then atomically
   # rename the validated staging tree into the final version directory.


### PR DESCRIPTION
Verify macOS Gatekeeper acceptance during install and only strip quarantine as a fallback when assessment fails. Applied to the **nightly** and **experimental** installers only; **eap** and **release** are intentionally left byte-identical for a later pass.

### What changed
- `templates/install.sh.template`: for nightly/experimental, run `codesign --verify --deep --strict` (informational) and `spctl --assess --type execute`; only on a failed assessment strip quarantine via absolute-path, fully-silenced `/usr/bin/xattr -dr com.apple.quarantine` (avoids the JUNIE-2906 foreign-`xattr` shadowing and the stdout usage-text leak). release/eap keep the original line verbatim.
- `templates/generate.sh`: added channel-conditional template blocks (`{{#channels:a,b}}`/`{{^channels:a,b}}`) so a single template emits per-channel output.
- Regenerated `install-nightly.sh` and `install-experimental.sh`; `install.sh` (release) and `install-eap.sh` are unchanged.

### Verification
- `diff` confirms release/eap installers byte-identical to before.
- `bash -n` passes on all four installers; `./templates/generate.sh --check` reports everything up to date.