### PR TITLE
JUNIE-3256 Shim CRLF Line Endings

### DIFF
--- a/install-eap.ps1
+++ b/install-eap.ps1
@@ -544,6 +544,12 @@ for %%A in (%*) do (
 :: place during auto-update (see ShimUpdater on the binary side).
 endlocal & set "EJ_RUNNER_PWD=%EJ_RUNNER_PWD%" & set "JUNIE_DATA=%JUNIE_DATA%" & set "JUNIE_SHIM_PATH=%~f0" & "%JUNIE_EXE%" %FILTERED_ARGS%
 '@
+  # The shim is a cmd.exe batch file: it MUST use Windows CRLF line endings.
+  # This template is maintained with LF, so normalize before writing -- otherwise
+  # `goto`/`call` label seeking breaks on LF-only files (e.g. the forward jump to
+  # :after_channel_oneshot), causing "The system cannot find the batch label
+  # specified" on launch.
+  $SHIM_CONTENT = $SHIM_CONTENT -replace "`r?`n", "`r`n"
   [System.IO.File]::WriteAllText($SHIM_PATH, $SHIM_CONTENT)
 
   Log "Installed successfully!"

--- a/install-experimental.ps1
+++ b/install-experimental.ps1
@@ -544,6 +544,12 @@ for %%A in (%*) do (
 :: place during auto-update (see ShimUpdater on the binary side).
 endlocal & set "EJ_RUNNER_PWD=%EJ_RUNNER_PWD%" & set "JUNIE_DATA=%JUNIE_DATA%" & set "JUNIE_SHIM_PATH=%~f0" & "%JUNIE_EXE%" %FILTERED_ARGS%
 '@
+  # The shim is a cmd.exe batch file: it MUST use Windows CRLF line endings.
+  # This template is maintained with LF, so normalize before writing -- otherwise
+  # `goto`/`call` label seeking breaks on LF-only files (e.g. the forward jump to
+  # :after_channel_oneshot), causing "The system cannot find the batch label
+  # specified" on launch.
+  $SHIM_CONTENT = $SHIM_CONTENT -replace "`r?`n", "`r`n"
   [System.IO.File]::WriteAllText($SHIM_PATH, $SHIM_CONTENT)
 
   Log "Installed successfully!"

--- a/install-nightly.ps1
+++ b/install-nightly.ps1
@@ -544,6 +544,12 @@ for %%A in (%*) do (
 :: place during auto-update (see ShimUpdater on the binary side).
 endlocal & set "EJ_RUNNER_PWD=%EJ_RUNNER_PWD%" & set "JUNIE_DATA=%JUNIE_DATA%" & set "JUNIE_SHIM_PATH=%~f0" & "%JUNIE_EXE%" %FILTERED_ARGS%
 '@
+  # The shim is a cmd.exe batch file: it MUST use Windows CRLF line endings.
+  # This template is maintained with LF, so normalize before writing -- otherwise
+  # `goto`/`call` label seeking breaks on LF-only files (e.g. the forward jump to
+  # :after_channel_oneshot), causing "The system cannot find the batch label
+  # specified" on launch.
+  $SHIM_CONTENT = $SHIM_CONTENT -replace "`r?`n", "`r`n"
   [System.IO.File]::WriteAllText($SHIM_PATH, $SHIM_CONTENT)
 
   Log "Installed successfully!"

--- a/install.ps1
+++ b/install.ps1
@@ -544,6 +544,12 @@ for %%A in (%*) do (
 :: place during auto-update (see ShimUpdater on the binary side).
 endlocal & set "EJ_RUNNER_PWD=%EJ_RUNNER_PWD%" & set "JUNIE_DATA=%JUNIE_DATA%" & set "JUNIE_SHIM_PATH=%~f0" & "%JUNIE_EXE%" %FILTERED_ARGS%
 '@
+  # The shim is a cmd.exe batch file: it MUST use Windows CRLF line endings.
+  # This template is maintained with LF, so normalize before writing -- otherwise
+  # `goto`/`call` label seeking breaks on LF-only files (e.g. the forward jump to
+  # :after_channel_oneshot), causing "The system cannot find the batch label
+  # specified" on launch.
+  $SHIM_CONTENT = $SHIM_CONTENT -replace "`r?`n", "`r`n"
   [System.IO.File]::WriteAllText($SHIM_PATH, $SHIM_CONTENT)
 
   Log "Installed successfully!"

--- a/templates/install.ps1.template
+++ b/templates/install.ps1.template
@@ -196,6 +196,12 @@ if ($ONESHOT) {
   $SHIM_CONTENT = @'
 {{SHIM}}
 '@
+  # The shim is a cmd.exe batch file: it MUST use Windows CRLF line endings.
+  # This template is maintained with LF, so normalize before writing -- otherwise
+  # `goto`/`call` label seeking breaks on LF-only files (e.g. the forward jump to
+  # :after_channel_oneshot), causing "The system cannot find the batch label
+  # specified" on launch.
+  $SHIM_CONTENT = $SHIM_CONTENT -replace "`r?`n", "`r`n"
   [System.IO.File]::WriteAllText($SHIM_PATH, $SHIM_CONTENT)
 
   Log "Installed successfully!"

--- a/tests/install_shim_crlf.sh
+++ b/tests/install_shim_crlf.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+#
+# Regression test for JUNIE-3256: the Windows shim (`junie.bat`) must be written
+# with CRLF line endings. cmd.exe `goto`/`call` label seeking is unreliable on
+# LF-only files (e.g. the forward jump to :after_channel_oneshot), which caused
+# "The system cannot find the batch label specified - after_channel_oneshot" on
+# launch.
+#
+# The shim template in this repo is maintained with LF, so each generated
+# install*.ps1 MUST normalize $SHIM_CONTENT to CRLF immediately before writing
+# it to disk. This test asserts that, for every Windows installer, the CRLF
+# normalization appears and precedes the WriteAllText that creates the shim.
+#
+# Usage:
+#   bash tests/install_shim_crlf.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+PS1_INSTALLERS=(
+  "install.ps1"
+  "install-eap.ps1"
+  "install-nightly.ps1"
+  "install-experimental.ps1"
+)
+
+PASS=0
+FAIL=0
+
+for name in "${PS1_INSTALLERS[@]}"; do
+  f="$REPO_ROOT/$name"
+  if [[ ! -f "$f" ]]; then
+    echo "FAIL [$name]: installer not found at $f" >&2
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+
+  # Line that normalizes the shim content to CRLF.
+  norm_line="$(grep -n 'SHIM_CONTENT = \$SHIM_CONTENT -replace' "$f" | head -1 | cut -d: -f1)"
+  # Line that writes the shim to disk.
+  write_line="$(grep -n 'WriteAllText(\$SHIM_PATH' "$f" | head -1 | cut -d: -f1)"
+
+  if [[ -z "$norm_line" ]]; then
+    echo "FAIL [$name]: missing CRLF normalization of \$SHIM_CONTENT before writing the shim" >&2
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+  if [[ -z "$write_line" ]]; then
+    echo "FAIL [$name]: could not find shim WriteAllText(\$SHIM_PATH ...) call" >&2
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+  if [[ "$norm_line" -ge "$write_line" ]]; then
+    echo "FAIL [$name]: CRLF normalization (line $norm_line) must precede shim write (line $write_line)" >&2
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+
+  echo "PASS [$name]"
+  PASS=$((PASS + 1))
+done
+
+echo "----"
+echo "PASS: $PASS  FAIL: $FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Fixes [JUNIE-3256](https://youtrack.jetbrains.com/issue/JUNIE-3256): on Windows, launching Junie CLI fails with **"The system cannot find the batch label specified - after_channel_oneshot"**.

### Root cause
The Windows shim `~/.local/bin/junie.bat` is a `cmd.exe` batch file but was written with **LF** line endings. cmd's `goto`/`call` rely on byte-offset seeking; on LF-only files a forward jump to a far label is unreliable. The forward jump to `:after_channel_oneshot` introduced in #65 exposed the latent issue.

The PowerShell installer wrote the shim verbatim from an LF here-string:
```powershell
[System.IO.File]::WriteAllText($SHIM_PATH, $SHIM_CONTENT)
```
`WriteAllText` performs no newline normalization, so LF flowed straight into the installed `.bat`.

### Fix
Normalize `$SHIM_CONTENT` to CRLF before writing, in `templates/install.ps1.template`:
```powershell
$SHIM_CONTENT = $SHIM_CONTENT -replace "\`r?\`n", "\`r\`n"
```
Regenerated all four channel installers (`install.ps1`, `install-eap.ps1`, `install-nightly.ps1`, `install-experimental.ps1`) via `templates/generate.sh`.

### Tests
Added `tests/install_shim_crlf.sh` asserting the CRLF normalization is present and precedes the shim write in every installer. `generate.sh --check` is clean and existing shim tests still pass.

### Note
The binary-side `ShimUpdater` (separate repo) that rewrites the shim during auto-update should also emit CRLF to fully prevent reintroduction on self-update.