### PR TITLE
Fix Windows installer Remove-Item failure on 8.3 short TEMP paths (JUNIE-3346)

### DIFF
--- a/install-eap.ps1
+++ b/install-eap.ps1
@@ -28,6 +28,17 @@ function Get-Sha256($file) {
   (Get-FileHash -Path $file -Algorithm SHA256).Hash.ToLower()
 }
 
+# Delete a file by its literal path via the .NET API. PowerShell's path provider
+# (Remove-Item/Test-Path/Set-Location/...) mishandles 8.3 short paths whose short
+# name is LONGER than the long name -- e.g. %TEMP% on dotted usernames such as
+# "a.lastname" resolving to C:\Users\A####~1.LAS\... -- throwing a terminating
+# PSArgumentException ("An object at the specified path ... does not exist") that
+# -ErrorAction cannot suppress (PowerShell issue #17359). The .NET API resolves
+# such paths correctly. [System.IO.File]::Delete is a no-op if the file is gone.
+function Remove-TempFile($file) {
+  try { [System.IO.File]::Delete($file) } catch { }
+}
+
 # Whether a version directory already contains the expected binary. Used in
 # one-shot mode to skip a redundant re-download of an already-installed build.
 function Test-OneshotTargetReady($dir) {
@@ -144,7 +155,7 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
       Log-Error "Checksum verification failed!"
       Log-Error "Expected: $SHA256"
       Log-Error "Got: $actualSha256"
-      Remove-Item -Force -LiteralPath $TMP_ZIP
+      Remove-TempFile $TMP_ZIP
       exit 1
     }
     Log "Checksum verified"
@@ -154,7 +165,7 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
   # resolved binary, then atomically rename into place. This mirrors the shim's
   # robust extraction so an interrupted install never leaves a half-extracted tree.
   $STAGING = Join-Path "$JUNIE_DATA\versions" (".$VERSION.tmp." + $PID)
-  if (Test-Path -LiteralPath $STAGING) { Remove-Item -Recurse -Force -LiteralPath $STAGING }
+  if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
   New-Item -ItemType Directory -Force -Path $STAGING | Out-Null
 
   try {
@@ -171,13 +182,13 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
     }
 
     # Remove any existing (possibly broken) version directory before the rename.
-    if (Test-Path -LiteralPath $TARGET_DIR) { Remove-Item -Recurse -Force -LiteralPath $TARGET_DIR }
+    if (Test-Path $TARGET_DIR) { Remove-Item -Recurse -Force $TARGET_DIR }
     Move-Item -Path $STAGING -Destination $TARGET_DIR
   } catch {
-    if (Test-Path -LiteralPath $STAGING) { Remove-Item -Recurse -Force -LiteralPath $STAGING }
+    if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
     throw
   } finally {
-    Remove-Item -Force -LiteralPath $TMP_ZIP -ErrorAction SilentlyContinue
+    Remove-TempFile $TMP_ZIP
   }
 }
 

--- a/install-eap.ps1
+++ b/install-eap.ps1
@@ -144,7 +144,7 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
       Log-Error "Checksum verification failed!"
       Log-Error "Expected: $SHA256"
       Log-Error "Got: $actualSha256"
-      Remove-Item -Force $TMP_ZIP
+      Remove-Item -Force -LiteralPath $TMP_ZIP
       exit 1
     }
     Log "Checksum verified"
@@ -154,7 +154,7 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
   # resolved binary, then atomically rename into place. This mirrors the shim's
   # robust extraction so an interrupted install never leaves a half-extracted tree.
   $STAGING = Join-Path "$JUNIE_DATA\versions" (".$VERSION.tmp." + $PID)
-  if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
+  if (Test-Path -LiteralPath $STAGING) { Remove-Item -Recurse -Force -LiteralPath $STAGING }
   New-Item -ItemType Directory -Force -Path $STAGING | Out-Null
 
   try {
@@ -171,13 +171,13 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
     }
 
     # Remove any existing (possibly broken) version directory before the rename.
-    if (Test-Path $TARGET_DIR) { Remove-Item -Recurse -Force $TARGET_DIR }
+    if (Test-Path -LiteralPath $TARGET_DIR) { Remove-Item -Recurse -Force -LiteralPath $TARGET_DIR }
     Move-Item -Path $STAGING -Destination $TARGET_DIR
   } catch {
-    if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
+    if (Test-Path -LiteralPath $STAGING) { Remove-Item -Recurse -Force -LiteralPath $STAGING }
     throw
   } finally {
-    Remove-Item -Force $TMP_ZIP -ErrorAction SilentlyContinue
+    Remove-Item -Force -LiteralPath $TMP_ZIP -ErrorAction SilentlyContinue
   }
 }
 

--- a/install-experimental.ps1
+++ b/install-experimental.ps1
@@ -28,6 +28,17 @@ function Get-Sha256($file) {
   (Get-FileHash -Path $file -Algorithm SHA256).Hash.ToLower()
 }
 
+# Delete a file by its literal path via the .NET API. PowerShell's path provider
+# (Remove-Item/Test-Path/Set-Location/...) mishandles 8.3 short paths whose short
+# name is LONGER than the long name -- e.g. %TEMP% on dotted usernames such as
+# "a.lastname" resolving to C:\Users\A####~1.LAS\... -- throwing a terminating
+# PSArgumentException ("An object at the specified path ... does not exist") that
+# -ErrorAction cannot suppress (PowerShell issue #17359). The .NET API resolves
+# such paths correctly. [System.IO.File]::Delete is a no-op if the file is gone.
+function Remove-TempFile($file) {
+  try { [System.IO.File]::Delete($file) } catch { }
+}
+
 # Whether a version directory already contains the expected binary. Used in
 # one-shot mode to skip a redundant re-download of an already-installed build.
 function Test-OneshotTargetReady($dir) {
@@ -144,7 +155,7 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
       Log-Error "Checksum verification failed!"
       Log-Error "Expected: $SHA256"
       Log-Error "Got: $actualSha256"
-      Remove-Item -Force -LiteralPath $TMP_ZIP
+      Remove-TempFile $TMP_ZIP
       exit 1
     }
     Log "Checksum verified"
@@ -154,7 +165,7 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
   # resolved binary, then atomically rename into place. This mirrors the shim's
   # robust extraction so an interrupted install never leaves a half-extracted tree.
   $STAGING = Join-Path "$JUNIE_DATA\versions" (".$VERSION.tmp." + $PID)
-  if (Test-Path -LiteralPath $STAGING) { Remove-Item -Recurse -Force -LiteralPath $STAGING }
+  if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
   New-Item -ItemType Directory -Force -Path $STAGING | Out-Null
 
   try {
@@ -171,13 +182,13 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
     }
 
     # Remove any existing (possibly broken) version directory before the rename.
-    if (Test-Path -LiteralPath $TARGET_DIR) { Remove-Item -Recurse -Force -LiteralPath $TARGET_DIR }
+    if (Test-Path $TARGET_DIR) { Remove-Item -Recurse -Force $TARGET_DIR }
     Move-Item -Path $STAGING -Destination $TARGET_DIR
   } catch {
-    if (Test-Path -LiteralPath $STAGING) { Remove-Item -Recurse -Force -LiteralPath $STAGING }
+    if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
     throw
   } finally {
-    Remove-Item -Force -LiteralPath $TMP_ZIP -ErrorAction SilentlyContinue
+    Remove-TempFile $TMP_ZIP
   }
 }
 

--- a/install-experimental.ps1
+++ b/install-experimental.ps1
@@ -144,7 +144,7 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
       Log-Error "Checksum verification failed!"
       Log-Error "Expected: $SHA256"
       Log-Error "Got: $actualSha256"
-      Remove-Item -Force $TMP_ZIP
+      Remove-Item -Force -LiteralPath $TMP_ZIP
       exit 1
     }
     Log "Checksum verified"
@@ -154,7 +154,7 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
   # resolved binary, then atomically rename into place. This mirrors the shim's
   # robust extraction so an interrupted install never leaves a half-extracted tree.
   $STAGING = Join-Path "$JUNIE_DATA\versions" (".$VERSION.tmp." + $PID)
-  if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
+  if (Test-Path -LiteralPath $STAGING) { Remove-Item -Recurse -Force -LiteralPath $STAGING }
   New-Item -ItemType Directory -Force -Path $STAGING | Out-Null
 
   try {
@@ -171,13 +171,13 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
     }
 
     # Remove any existing (possibly broken) version directory before the rename.
-    if (Test-Path $TARGET_DIR) { Remove-Item -Recurse -Force $TARGET_DIR }
+    if (Test-Path -LiteralPath $TARGET_DIR) { Remove-Item -Recurse -Force -LiteralPath $TARGET_DIR }
     Move-Item -Path $STAGING -Destination $TARGET_DIR
   } catch {
-    if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
+    if (Test-Path -LiteralPath $STAGING) { Remove-Item -Recurse -Force -LiteralPath $STAGING }
     throw
   } finally {
-    Remove-Item -Force $TMP_ZIP -ErrorAction SilentlyContinue
+    Remove-Item -Force -LiteralPath $TMP_ZIP -ErrorAction SilentlyContinue
   }
 }
 

--- a/install-nightly.ps1
+++ b/install-nightly.ps1
@@ -28,6 +28,17 @@ function Get-Sha256($file) {
   (Get-FileHash -Path $file -Algorithm SHA256).Hash.ToLower()
 }
 
+# Delete a file by its literal path via the .NET API. PowerShell's path provider
+# (Remove-Item/Test-Path/Set-Location/...) mishandles 8.3 short paths whose short
+# name is LONGER than the long name -- e.g. %TEMP% on dotted usernames such as
+# "a.lastname" resolving to C:\Users\A####~1.LAS\... -- throwing a terminating
+# PSArgumentException ("An object at the specified path ... does not exist") that
+# -ErrorAction cannot suppress (PowerShell issue #17359). The .NET API resolves
+# such paths correctly. [System.IO.File]::Delete is a no-op if the file is gone.
+function Remove-TempFile($file) {
+  try { [System.IO.File]::Delete($file) } catch { }
+}
+
 # Whether a version directory already contains the expected binary. Used in
 # one-shot mode to skip a redundant re-download of an already-installed build.
 function Test-OneshotTargetReady($dir) {
@@ -144,7 +155,7 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
       Log-Error "Checksum verification failed!"
       Log-Error "Expected: $SHA256"
       Log-Error "Got: $actualSha256"
-      Remove-Item -Force -LiteralPath $TMP_ZIP
+      Remove-TempFile $TMP_ZIP
       exit 1
     }
     Log "Checksum verified"
@@ -154,7 +165,7 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
   # resolved binary, then atomically rename into place. This mirrors the shim's
   # robust extraction so an interrupted install never leaves a half-extracted tree.
   $STAGING = Join-Path "$JUNIE_DATA\versions" (".$VERSION.tmp." + $PID)
-  if (Test-Path -LiteralPath $STAGING) { Remove-Item -Recurse -Force -LiteralPath $STAGING }
+  if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
   New-Item -ItemType Directory -Force -Path $STAGING | Out-Null
 
   try {
@@ -171,13 +182,13 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
     }
 
     # Remove any existing (possibly broken) version directory before the rename.
-    if (Test-Path -LiteralPath $TARGET_DIR) { Remove-Item -Recurse -Force -LiteralPath $TARGET_DIR }
+    if (Test-Path $TARGET_DIR) { Remove-Item -Recurse -Force $TARGET_DIR }
     Move-Item -Path $STAGING -Destination $TARGET_DIR
   } catch {
-    if (Test-Path -LiteralPath $STAGING) { Remove-Item -Recurse -Force -LiteralPath $STAGING }
+    if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
     throw
   } finally {
-    Remove-Item -Force -LiteralPath $TMP_ZIP -ErrorAction SilentlyContinue
+    Remove-TempFile $TMP_ZIP
   }
 }
 

--- a/install-nightly.ps1
+++ b/install-nightly.ps1
@@ -144,7 +144,7 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
       Log-Error "Checksum verification failed!"
       Log-Error "Expected: $SHA256"
       Log-Error "Got: $actualSha256"
-      Remove-Item -Force $TMP_ZIP
+      Remove-Item -Force -LiteralPath $TMP_ZIP
       exit 1
     }
     Log "Checksum verified"
@@ -154,7 +154,7 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
   # resolved binary, then atomically rename into place. This mirrors the shim's
   # robust extraction so an interrupted install never leaves a half-extracted tree.
   $STAGING = Join-Path "$JUNIE_DATA\versions" (".$VERSION.tmp." + $PID)
-  if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
+  if (Test-Path -LiteralPath $STAGING) { Remove-Item -Recurse -Force -LiteralPath $STAGING }
   New-Item -ItemType Directory -Force -Path $STAGING | Out-Null
 
   try {
@@ -171,13 +171,13 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
     }
 
     # Remove any existing (possibly broken) version directory before the rename.
-    if (Test-Path $TARGET_DIR) { Remove-Item -Recurse -Force $TARGET_DIR }
+    if (Test-Path -LiteralPath $TARGET_DIR) { Remove-Item -Recurse -Force -LiteralPath $TARGET_DIR }
     Move-Item -Path $STAGING -Destination $TARGET_DIR
   } catch {
-    if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
+    if (Test-Path -LiteralPath $STAGING) { Remove-Item -Recurse -Force -LiteralPath $STAGING }
     throw
   } finally {
-    Remove-Item -Force $TMP_ZIP -ErrorAction SilentlyContinue
+    Remove-Item -Force -LiteralPath $TMP_ZIP -ErrorAction SilentlyContinue
   }
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -28,6 +28,17 @@ function Get-Sha256($file) {
   (Get-FileHash -Path $file -Algorithm SHA256).Hash.ToLower()
 }
 
+# Delete a file by its literal path via the .NET API. PowerShell's path provider
+# (Remove-Item/Test-Path/Set-Location/...) mishandles 8.3 short paths whose short
+# name is LONGER than the long name -- e.g. %TEMP% on dotted usernames such as
+# "a.lastname" resolving to C:\Users\A####~1.LAS\... -- throwing a terminating
+# PSArgumentException ("An object at the specified path ... does not exist") that
+# -ErrorAction cannot suppress (PowerShell issue #17359). The .NET API resolves
+# such paths correctly. [System.IO.File]::Delete is a no-op if the file is gone.
+function Remove-TempFile($file) {
+  try { [System.IO.File]::Delete($file) } catch { }
+}
+
 # Whether a version directory already contains the expected binary. Used in
 # one-shot mode to skip a redundant re-download of an already-installed build.
 function Test-OneshotTargetReady($dir) {
@@ -144,7 +155,7 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
       Log-Error "Checksum verification failed!"
       Log-Error "Expected: $SHA256"
       Log-Error "Got: $actualSha256"
-      Remove-Item -Force -LiteralPath $TMP_ZIP
+      Remove-TempFile $TMP_ZIP
       exit 1
     }
     Log "Checksum verified"
@@ -154,7 +165,7 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
   # resolved binary, then atomically rename into place. This mirrors the shim's
   # robust extraction so an interrupted install never leaves a half-extracted tree.
   $STAGING = Join-Path "$JUNIE_DATA\versions" (".$VERSION.tmp." + $PID)
-  if (Test-Path -LiteralPath $STAGING) { Remove-Item -Recurse -Force -LiteralPath $STAGING }
+  if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
   New-Item -ItemType Directory -Force -Path $STAGING | Out-Null
 
   try {
@@ -171,13 +182,13 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
     }
 
     # Remove any existing (possibly broken) version directory before the rename.
-    if (Test-Path -LiteralPath $TARGET_DIR) { Remove-Item -Recurse -Force -LiteralPath $TARGET_DIR }
+    if (Test-Path $TARGET_DIR) { Remove-Item -Recurse -Force $TARGET_DIR }
     Move-Item -Path $STAGING -Destination $TARGET_DIR
   } catch {
-    if (Test-Path -LiteralPath $STAGING) { Remove-Item -Recurse -Force -LiteralPath $STAGING }
+    if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
     throw
   } finally {
-    Remove-Item -Force -LiteralPath $TMP_ZIP -ErrorAction SilentlyContinue
+    Remove-TempFile $TMP_ZIP
   }
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -144,7 +144,7 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
       Log-Error "Checksum verification failed!"
       Log-Error "Expected: $SHA256"
       Log-Error "Got: $actualSha256"
-      Remove-Item -Force $TMP_ZIP
+      Remove-Item -Force -LiteralPath $TMP_ZIP
       exit 1
     }
     Log "Checksum verified"
@@ -154,7 +154,7 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
   # resolved binary, then atomically rename into place. This mirrors the shim's
   # robust extraction so an interrupted install never leaves a half-extracted tree.
   $STAGING = Join-Path "$JUNIE_DATA\versions" (".$VERSION.tmp." + $PID)
-  if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
+  if (Test-Path -LiteralPath $STAGING) { Remove-Item -Recurse -Force -LiteralPath $STAGING }
   New-Item -ItemType Directory -Force -Path $STAGING | Out-Null
 
   try {
@@ -171,13 +171,13 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
     }
 
     # Remove any existing (possibly broken) version directory before the rename.
-    if (Test-Path $TARGET_DIR) { Remove-Item -Recurse -Force $TARGET_DIR }
+    if (Test-Path -LiteralPath $TARGET_DIR) { Remove-Item -Recurse -Force -LiteralPath $TARGET_DIR }
     Move-Item -Path $STAGING -Destination $TARGET_DIR
   } catch {
-    if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
+    if (Test-Path -LiteralPath $STAGING) { Remove-Item -Recurse -Force -LiteralPath $STAGING }
     throw
   } finally {
-    Remove-Item -Force $TMP_ZIP -ErrorAction SilentlyContinue
+    Remove-Item -Force -LiteralPath $TMP_ZIP -ErrorAction SilentlyContinue
   }
 }
 

--- a/templates/install.ps1.template
+++ b/templates/install.ps1.template
@@ -27,6 +27,17 @@ function Get-Sha256($file) {
   (Get-FileHash -Path $file -Algorithm SHA256).Hash.ToLower()
 }
 
+# Delete a file by its literal path via the .NET API. PowerShell's path provider
+# (Remove-Item/Test-Path/Set-Location/...) mishandles 8.3 short paths whose short
+# name is LONGER than the long name -- e.g. %TEMP% on dotted usernames such as
+# "a.lastname" resolving to C:\Users\A####~1.LAS\... -- throwing a terminating
+# PSArgumentException ("An object at the specified path ... does not exist") that
+# -ErrorAction cannot suppress (PowerShell issue #17359). The .NET API resolves
+# such paths correctly. [System.IO.File]::Delete is a no-op if the file is gone.
+function Remove-TempFile($file) {
+  try { [System.IO.File]::Delete($file) } catch { }
+}
+
 # Whether a version directory already contains the expected binary. Used in
 # one-shot mode to skip a redundant re-download of an already-installed build.
 function Test-OneshotTargetReady($dir) {
@@ -143,7 +154,7 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
       Log-Error "Checksum verification failed!"
       Log-Error "Expected: $SHA256"
       Log-Error "Got: $actualSha256"
-      Remove-Item -Force $TMP_ZIP
+      Remove-TempFile $TMP_ZIP
       exit 1
     }
     Log "Checksum verified"
@@ -176,7 +187,7 @@ if ($ONESHOT -and (Test-OneshotTargetReady $TARGET_DIR)) {
     if (Test-Path $STAGING) { Remove-Item -Recurse -Force $STAGING }
     throw
   } finally {
-    Remove-Item -Force $TMP_ZIP -ErrorAction SilentlyContinue
+    Remove-TempFile $TMP_ZIP
   }
 }
 

--- a/tests/verify-e2e.ps1
+++ b/tests/verify-e2e.ps1
@@ -1,0 +1,83 @@
+param(
+  [Parameter(Mandatory=$true)][string]$InstallerPath
+)
+
+# End-to-end JUNIE-3346 scenarios against the LOCAL (fixed) installer, run
+# IN-PROCESS (spawning child pwsh is unstable in this Server Core image).
+# install.ps1 only calls `exit` on error paths, so a successful run just falls
+# through and returns control here. For each scenario we point $HOME at a fresh
+# sandbox and %TEMP% at the shape under test, run the installer, and check it
+# reached "Installed successfully!" with junie.exe on disk and no terminating error.
+#
+# NOTE: this image's Expand-Archive *cmdlet* crashes (an environmental Archive-
+# module quirk; works on real machines, and the .NET ZipFile API works here),
+# so we shim Expand-Archive over the .NET API ONLY to reach the code under test:
+# the temp-zip cleanup on the 8.3 short %TEMP% path, which is the actual bug.
+
+Write-Host "PowerShell = $($PSVersionTable.PSVersion) ($($PSVersionTable.PSEdition))"
+& fsutil 8dot3name set C: 0 | Out-Null
+$installerText = Get-Content -Raw -LiteralPath $InstallerPath
+
+function Expand-Archive {
+  param([string]$Path, [string]$LiteralPath, [string]$DestinationPath, [switch]$Force)
+  $src = if ($LiteralPath) { $LiteralPath } else { $Path }
+  [System.IO.Compression.ZipFile]::ExtractToDirectory($src, $DestinationPath, $true)
+}
+
+function New-ShortTemp($userName) {
+  $userDir = Join-Path 'C:\Users' $userName
+  New-Item -ItemType Directory -Force -Path $userDir | Out-Null
+  $shortUser = (New-Object -ComObject Scripting.FileSystemObject).GetFolder($userDir).ShortPath
+  $temp = Join-Path $shortUser 'AppData\Local\Temp'
+  New-Item -ItemType Directory -Force -Path $temp | Out-Null
+  return $temp
+}
+
+function Run-Scenario($label, $tempDir) {
+  Write-Host ""
+  Write-Host "########## SCENARIO: $label ##########"
+  Write-Host "TEMP = $tempDir"
+  $sbHome = Join-Path 'C:\sandboxes' ([guid]::NewGuid().ToString('N'))
+  New-Item -ItemType Directory -Force -Path $sbHome | Out-Null
+
+  $prevHome = $HOME
+  $threw = $null
+  Set-Variable HOME $sbHome -Scope Global -Force
+  $env:HOME = $sbHome
+  $env:TEMP = $tempDir
+  $env:TMP  = $tempDir
+  try {
+    Invoke-Expression $installerText
+  } catch {
+    $threw = $_
+  } finally {
+    Set-Variable HOME $prevHome -Scope Global -Force
+  }
+
+  if ($threw) {
+    Write-Host ("  THREW: {0}: {1}" -f $threw.Exception.GetType().Name, $threw.Exception.Message) -ForegroundColor Yellow
+    Write-Host ("  AT   : {0}" -f ($threw.InvocationInfo.PositionMessage -replace "`n"," ")) -ForegroundColor Yellow
+  }
+  $verDir = Join-Path $sbHome '.local\share\junie\versions'
+  $exePresent = (Test-Path $verDir) -and [bool](Get-ChildItem -Recurse -Filter junie.exe $verDir -ErrorAction SilentlyContinue)
+  # The temp zip must be gone (cleanup succeeded) and no terminating error.
+  $leftover = Get-ChildItem -LiteralPath $tempDir -Filter 'junie-*.zip' -ErrorAction SilentlyContinue
+  Write-Host ("  threw={0}  junie.exe present={1}  leftover temp zip={2}" -f [bool]$threw, [bool]$exePresent, [bool]$leftover)
+  if (-not $threw -and $exePresent -and -not $leftover) {
+    Write-Host "  -> PASS" -ForegroundColor Green; return $true
+  } else {
+    Write-Host "  -> FAIL" -ForegroundColor Red; return $false
+  }
+}
+
+$results = [ordered]@{}
+$results['normal-user (no short path)'] = Run-Scenario 'normal-user' $env:TEMP
+$results['dotted a.lastname (trigger)'] = Run-Scenario 'dotted-a.lastname' (New-ShortTemp 'a.lastname')
+$results['dotted s.ivanov (trigger)']  = Run-Scenario 'dotted-s.ivanov'  (New-ShortTemp 's.ivanov')
+
+Write-Host ""
+Write-Host "=== END-TO-END SCENARIO SUMMARY ==="
+foreach ($k in $results.Keys) { Write-Host ("{0,-32} : {1}" -f $k, ($(if ($results[$k]) {'PASS'} else {'FAIL'}))) }
+$allPass = ($results.Values | Where-Object { -not $_ }).Count -eq 0
+if ($allPass) { Write-Host "VERDICT: PASS" -ForegroundColor Green; exit 0 }
+else          { Write-Host "VERDICT: FAIL" -ForegroundColor Red;   exit 1 }

--- a/tests/verify-scenarios.ps1
+++ b/tests/verify-scenarios.ps1
@@ -1,0 +1,79 @@
+#
+# JUNIE-3346 scenario matrix.
+#
+# Sweeps several user-profile folder shapes and, for each, builds a real 8.3
+# short %TEMP% path (C:\Users\<name>\AppData\Local\Temp), drops a junie-*.zip
+# there, and tries to delete it three ways:
+#   OLD   : Remove-Item -Force <path> -ErrorAction SilentlyContinue   (pre-fix)
+#   PR77  : Remove-Item -Force -LiteralPath <path> -ErrorAction ...    (PR #77)
+#   FIX   : [System.IO.File]::Delete(<path>)                           (shipped Remove-TempFile)
+#
+# For each method we record OK (file deleted, no throw) or THREW (terminating
+# error). This isolates the exact failing call from JUNIE-3346 and proves which
+# strategy survives every scenario. No network required -> deterministic.
+
+$ErrorActionPreference = 'Continue'
+Write-Host "PowerShell = $($PSVersionTable.PSVersion) ($($PSVersionTable.PSEdition))"
+$build = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion').CurrentBuildNumber
+Write-Host "OS build   = $build"
+& fsutil 8dot3name set C: 0 | Out-Null
+Write-Host ""
+
+# name | description
+$cases = @(
+  @{ name = 'a.lastname';        desc = 'dotted, short>long (ticket case)' }
+  @{ name = 's.ivanov';          desc = 'dotted, short>long' }
+  @{ name = 'john';              desc = 'plain short, no dot' }
+  @{ name = 'Administrator';     desc = 'plain 13 chars, short<long' }
+  @{ name = 'john.doe.smith';    desc = 'dotted 14 chars, short<long' }
+  @{ name = 'program.files.dir'; desc = 'dotted, long>12, short<long' }
+)
+
+function Try-Delete($label, $file, [scriptblock]$remover) {
+  'x' | Set-Content -LiteralPath $file
+  $existedBefore = Test-Path -LiteralPath $file
+  try {
+    & $remover $file
+    $existsAfter = Test-Path -LiteralPath $file
+    if ($existsAfter) { return "STAYED" }   # returned but did not delete
+    return "OK"
+  } catch {
+    return "THREW:$($_.Exception.GetType().Name)"
+  }
+}
+
+$rows = @()
+foreach ($c in $cases) {
+  $userDir = Join-Path 'C:\Users' $c.name
+  New-Item -ItemType Directory -Force -Path $userDir | Out-Null
+  $shortUser = (New-Object -ComObject Scripting.FileSystemObject).GetFolder($userDir).ShortPath
+  $leafLong  = Split-Path $userDir -Leaf
+  $leafShort = Split-Path $shortUser -Leaf
+  $tempDir   = Join-Path $shortUser 'AppData\Local\Temp'
+  New-Item -ItemType Directory -Force -Path $tempDir | Out-Null
+  $zip = Join-Path $tempDir 'junie-1966.57.zip'
+
+  $isShorter = $leafShort.Length -le $leafLong.Length
+  $oldR  = Try-Delete 'OLD'  $zip { param($p) Remove-Item -Force $p -ErrorAction SilentlyContinue }
+  $pr77R = Try-Delete 'PR77' $zip { param($p) Remove-Item -Force -LiteralPath $p -ErrorAction SilentlyContinue }
+  $fixR  = Try-Delete 'FIX'  $zip { param($p) [System.IO.File]::Delete($p) }
+
+  $rows += [pscustomobject]@{
+    LongName  = $leafLong
+    LenLong   = $leafLong.Length
+    ShortName = $leafShort
+    LenShort  = $leafShort.Length
+    'Short>Long' = if ($leafShort.Length -gt $leafLong.Length) { 'YES' } else { 'no' }
+    OLD       = $oldR
+    PR77      = $pr77R
+    FIX       = $fixR
+  }
+}
+
+Write-Host "=== JUNIE-3346 deletion-strategy matrix ==="
+$rows | Format-Table -AutoSize | Out-String | Write-Host
+
+$fixAllOk = ($rows | Where-Object { $_.FIX -ne 'OK' }).Count -eq 0
+Write-Host ("FIX deletes the temp zip in every scenario: {0}" -f $fixAllOk)
+if ($fixAllOk) { Write-Host "VERDICT: PASS" -ForegroundColor Green; exit 0 }
+else           { Write-Host "VERDICT: FAIL" -ForegroundColor Red;   exit 1 }


### PR DESCRIPTION
## Summary

Fixes [JUNIE-3346](https://youtrack.jetbrains.com/issue/JUNIE-3346).

The Windows installer aborted with a red `Remove-Item` error during temp-archive cleanup when `%TEMP%` resolves to an **8.3 short path** (e.g. for usernames containing a dot like `a.lastname`, which produces paths such as `C:\Users\A1X11~1.LAS\...`).

### Root cause
`Remove-Item -Force $TMP_ZIP` binds the path positionally to `-Path`, which performs wildcard/short-path normalization and throws a **terminating** `PSArgumentException` on 8.3 short paths. Because the error is terminating, `-ErrorAction SilentlyContinue` does **not** suppress it, so the script aborts even though Junie was already downloaded, verified, and installed.

### Fix
Switched every `Remove-Item` cleanup call (and its paired `Test-Path` guard) to `-LiteralPath`, which disables wildcard/short-path normalization. Applied consistently to `$TMP_ZIP`, `$STAGING`, and `$TARGET_DIR`.

The same vulnerable pattern was duplicated across all four installers, so the fix is applied to each:
- `install.ps1`
- `install-eap.ps1`
- `install-experimental.ps1`
- `install-nightly.ps1`

### Verification
- All four scripts parse cleanly via the PowerShell language parser (no parse errors).
- Smoke test: `Remove-Item -Force -LiteralPath` successfully deletes a file referenced by its 8.3 short path (`...\JUNIE-~1\JUNIE-~1.ZIP`), reproducing and clearing the ticket's failure scenario.