### PR TITLE
Switching bash shebangs to `#!/usr/bin/env bash` for better portability

### DIFF
--- a/install-eap.sh
+++ b/install-eap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # DO NOT EDIT — generated from templates/install.sh.template by templates/generate.sh
 #
 # Junie CLI Installer
@@ -242,7 +242,7 @@ fi
 # Install shim (skipped in one-shot mode so the existing shim stays intact)
 if [[ -z "$ONESHOT" ]]; then
 cat > "$JUNIE_BIN/junie" << 'SHIM_EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # JUNIE_MANAGED_SHIM
 #

--- a/install-experimental.sh
+++ b/install-experimental.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # DO NOT EDIT — generated from templates/install.sh.template by templates/generate.sh
 #
 # Junie CLI Installer
@@ -242,7 +242,7 @@ fi
 # Install shim (skipped in one-shot mode so the existing shim stays intact)
 if [[ -z "$ONESHOT" ]]; then
 cat > "$JUNIE_BIN/junie" << 'SHIM_EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # JUNIE_MANAGED_SHIM
 #

--- a/install-nightly.sh
+++ b/install-nightly.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # DO NOT EDIT — generated from templates/install.sh.template by templates/generate.sh
 #
 # Junie CLI Installer
@@ -242,7 +242,7 @@ fi
 # Install shim (skipped in one-shot mode so the existing shim stays intact)
 if [[ -z "$ONESHOT" ]]; then
 cat > "$JUNIE_BIN/junie" << 'SHIM_EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # JUNIE_MANAGED_SHIM
 #

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # DO NOT EDIT — generated from templates/install.sh.template by templates/generate.sh
 #
 # Junie CLI Installer
@@ -242,7 +242,7 @@ fi
 # Install shim (skipped in one-shot mode so the existing shim stays intact)
 if [[ -z "$ONESHOT" ]]; then
 cat > "$JUNIE_BIN/junie" << 'SHIM_EOF'
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # JUNIE_MANAGED_SHIM
 #

--- a/templates/install.sh.template
+++ b/templates/install.sh.template
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Junie CLI Installer
 # Usage: curl -fsSL https://junie.jetbrains.com/install.sh | bash

--- a/templates/junie.shim.sh
+++ b/templates/junie.shim.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # JUNIE_MANAGED_SHIM
 #

--- a/tests/install_latest_version.sh
+++ b/tests/install_latest_version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Regression test: installers must select the greatest numeric version for the
 # current platform, regardless of JSONL entry order.

--- a/tests/install_local_model.sh
+++ b/tests/install_local_model.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Regression test: the `--local-model` flag must be accepted, unknown flags must
 # be rejected, and the local model setup must run only when the flag is given.

--- a/tests/install_shim_crlf.sh
+++ b/tests/install_shim_crlf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Regression test for JUNIE-3256: the Windows shim (`junie.bat`) must be written
 # with CRLF line endings. cmd.exe `goto`/`call` label seeking is unreliable on

--- a/tests/shim_atomic_extract.sh
+++ b/tests/shim_atomic_extract.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Self-test for the atomic-extraction shim embedded in install.sh.
 #

--- a/tests/shim_channel_switch.sh
+++ b/tests/shim_channel_switch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Self-test for the one-shot channel-switching logic in the shim embedded in
 # install.sh (`junie --eap` and friends).


### PR DESCRIPTION
Should fix #22